### PR TITLE
Adding securityContext to the deployment

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "reflector.serviceAccountName" . }}
       {{- end }}


### PR DESCRIPTION
Adds the ability to set arbitrary securityContext values to the helm chart - addresses #31 