### PR TITLE
Remove default securityContext to work with OpenShift

### DIFF
--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -30,16 +30,9 @@ serviceAccount:
 rbac:
   enabled: true
 
-podSecurityContext:
-  fsGroup: 2000
+podSecurityContext: {}
 
-securityContext:
-  capabilities:
-    drop:
-    - ALL
-  readOnlyRootFilesystem: false
-  runAsNonRoot: true
-  runAsUser: 1000
+securityContext: {}
 
 livenessProbe:
   initialDelaySeconds: 5


### PR DESCRIPTION
Due to a bug in Helm, we can only override these values via the command line. We use ArgoCD to manage our K8s resources and ArgoCD does not support setting variables via `--set`. 

I looked and the values set in the `values.yaml` were the same as the defaults with the exception of the `runAsUser` and `fsGroup`. `runAsUser` will default to what's specified in the image and `fsGroup` seems to only impact volumes which none are mounted. 

If any of these are needed, users can pass them in locally via their values file. 