### PR TITLE
Added startupProbe to chart

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -54,6 +54,14 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- if semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -51,6 +51,10 @@ livenessProbe:
 readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
+startupProbe:
+  # The application will have a maximum of 50s (10 * 5 = 50s) to finish its startup.
+  failureThreshold: 10
+  periodSeconds: 5
 
 resources:
   {}


### PR DESCRIPTION
Fix #251

Added `startupProbe` to the chart conditionally by the K8s version, and the default values into `values.yaml`
Tested on K8s v1.17.17 and v1.21.1.