### PR TITLE
[Resolve #268] Added priority class support to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can customize the values of the helm deployment by using the following Value
 | `nodeSelector`                       | Node labels for pod assignment                   | `{}`                                                    |
 | `tolerations`                        | Toleration labels for pod assignment             | `[]`                                                    |
 | `affinity`                           | Node affinity for pod assignment                 | `{}`                                                    |
+| `priorityClassName`                  | `priorityClassName` for pods                     | `""`                                                    |
 
 > Find us on [Artifact Hub](https://artifacthub.io/packages/helm/emberstack/reflector)
 

--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       serviceAccountName: {{ include "reflector.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -81,3 +81,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+priorityClassName: ""


### PR DESCRIPTION
Resolves #268 
Added `priorityClassName` in `values.yaml`.  `deployment.yaml` checks if  `priorityClassName` is set. If so, set priority class for pods.
Also updated the documentation.