### PR TITLE
fix: Add namespaces for GitOps deploys 

### DIFF
--- a/src/helm/reflector/templates/clusterRole.yaml
+++ b/src/helm/reflector/templates/clusterRole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "reflector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 rules:

--- a/src/helm/reflector/templates/clusterRoleBinding.yaml
+++ b/src/helm/reflector/templates/clusterRoleBinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "reflector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 roleRef:

--- a/src/helm/reflector/templates/cron.yaml
+++ b/src/helm/reflector/templates/cron.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ .Values.cron.apiVersion | default "batch/v1beta1" }}
 kind: CronJob
 metadata:
   name: {{ include "reflector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 

--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reflector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 spec:

--- a/src/helm/reflector/templates/hpa.yaml
+++ b/src/helm/reflector/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "reflector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 spec:

--- a/src/helm/reflector/templates/serviceaccount.yaml
+++ b/src/helm/reflector/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "reflector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Some people need to have the namespace in the manifests when rendered. I render the manifests so i can review the rendered output in a Github PR. 

Flux picks up the rendered manifests afterwards. The issue is that Flux cannot use these manifests without specifying a namespace.

This won't hinder current Helm deployments as it stands.