### PR TITLE
fix: use autoscaling/v2 API version

### DIFF
--- a/src/helm/reflector/templates/hpa.yaml
+++ b/src/helm/reflector/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "reflector.fullname" . }}


### PR DESCRIPTION
The autoscaling/v2beta2 API was removed in 1.26.
Docs: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126