### PR TITLE
Properly clear `TResources` and fix race condition

### DIFF
--- a/src/ES.Kubernetes.Reflector/Core/Mirroring/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/Mirroring/ResourceMirror.cs
@@ -49,6 +49,7 @@ public abstract class ResourceMirror<TResource> :
             notification.ResourceType != typeof(V1Namespace)) return Task.CompletedTask;
         if (notification.ResourceType != typeof(TResource)) return Task.CompletedTask;
 
+        Logger.LogDebug("Cleared sources for {Type} resources", typeof(TResource).Name);
 
         _autoSources.Clear();
         _notFoundCache.Clear();

--- a/src/ES.Kubernetes.Reflector/Core/Watchers/WatcherBackgroundService.cs
+++ b/src/ES.Kubernetes.Reflector/Core/Watchers/WatcherBackgroundService.cs
@@ -68,7 +68,7 @@ public abstract class WatcherBackgroundService<TResource, TResourceList> : Backg
 
                 await Mediator.Publish(new WatcherClosed
                 {
-                    ResourceType = typeof(V1Secret),
+                    ResourceType = typeof(TResource),
                     Faulted = sessionFaulted
                 }, stoppingToken);
 


### PR DESCRIPTION
This change ensures that the proper resource type gets cleared during `timeout`/`WatcherClosed`.

Previously, it was always calling against `V1Secret`, this caused it to clear the `V1Secret` ConcurrentDictionary(ies) 3 times.

```
2023-06-17 10:42:51.343 -04:00 [INF] (ES.Kubernetes.Reflector.Core.SecretWatcher) Session closed. Duration: 00:00:15.1274168. Faulted: False.
2023-06-17 10:42:51.343 -04:00 [INF] (ES.Kubernetes.Reflector.Core.ConfigMapWatcher) Session closed. Duration: 00:00:15.1206268. Faulted: False.
2023-06-17 10:42:51.343 -04:00 [INF] (ES.Kubernetes.Reflector.Core.NamespaceWatcher) Session closed. Duration: 00:00:15.2151075. Faulted: False.
2023-06-17 10:42:51.347 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
2023-06-17 10:42:51.347 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
2023-06-17 10:42:51.348 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
```

In some cases this could also lead to a race condition, where the actual `V1Secret` clears and regenerates, but then gets cleared again by one of the other threads closing.

```
2023-06-17 10:43:06.359 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
2023-06-17 10:43:06.359 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
2023-06-17 10:43:06.360 -04:00 [INF] (ES.Kubernetes.Reflector.Core.SecretWatcher) Requesting V1Secret resources
2023-06-17 10:43:06.361 -04:00 [INF] (ES.Kubernetes.Reflector.Core.NamespaceWatcher) Session closed. Duration: 00:00:15.0102368. Faulted: False.
2023-06-17 10:43:06.362 -04:00 [INF] (ES.Kubernetes.Reflector.Core.ConfigMapWatcher) Requesting V1ConfigMap resources
2023-06-17 10:43:06.365 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
```

This change also adds a new debug log for `WatcherClosed` that I found to be helpful when troubleshooting this issue.

Related to: #337

After making this change, we can now see that `V1Secret` only gets cleared once, and now `V1ConfigMap` gets cleared, and nothing runs for `V1Namespace` as defined by the if statement

```
2023-06-17 10:52:28.125 -04:00 [INF] (ES.Kubernetes.Reflector.Core.SecretWatcher) Session closed. Duration: 00:00:15.1385409. Faulted: False.
2023-06-17 10:52:28.125 -04:00 [INF] (ES.Kubernetes.Reflector.Core.ConfigMapWatcher) Session closed. Duration: 00:00:15.1308554. Faulted: False.
2023-06-17 10:52:28.125 -04:00 [INF] (ES.Kubernetes.Reflector.Core.NamespaceWatcher) Session closed. Duration: 00:00:15.2297132. Faulted: False.
2023-06-17 10:52:28.128 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.SecretMirror) Cleared sources for V1Secret resources
2023-06-17 10:52:28.128 -04:00 [DBG] (ES.Kubernetes.Reflector.Core.ConfigMapMirror) Cleared sources for V1ConfigMap resources
2023-06-17 10:52:28.129 -04:00 [INF] (ES.Kubernetes.Reflector.Core.NamespaceWatcher) Requesting V1Namespace resources
2023-06-17 10:52:28.130 -04:00 [INF] (ES.Kubernetes.Reflector.Core.SecretWatcher) Requesting V1Secret resources
2023-06-17 10:52:28.131 -04:00 [INF] (ES.Kubernetes.Reflector.Core.ConfigMapWatcher) Requesting V1ConfigMap resources
```