### PR TITLE
chore: Automatically generate release notes

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -170,6 +170,7 @@ jobs:
           repository: emberstack/kubernetes-reflector
           tag_name: v${{env.version}}
           body: The release process is automated.
+          generate_release_notes: true
           token: ${{ secrets.ES_GITHUB_PAT }}
           files: |
             github/reflector.yaml


### PR DESCRIPTION
Activates the automatic release note generation of the [softprops/action-gh-release](https://github.com/softprops/action-gh-release#-customizing) action.
A changelog in the release's body is important for tools like Renovate. Without proper release notes it is difficult to lookup the changes of a version bump.