### PR TITLE
chore: Update default API version for CronJob

### DIFF
--- a/src/helm/reflector/templates/cron.yaml
+++ b/src/helm/reflector/templates/cron.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.cron.enabled }}
 ---
-apiVersion: {{ .Values.cron.apiVersion | default "batch/v1beta1" }}
+apiVersion: {{ .Values.cron.apiVersion | default "batch/v1" }}
 kind: CronJob
 metadata:
   name: {{ include "reflector.fullname" . }}
@@ -69,5 +69,5 @@ spec:
                 - name: ES_Reflector__Watcher__Timeout
                   value: {{ .Values.configuration.watcher.timeout | quote }}
               resources:
-                {{- toYaml .Values.resources | nindent 16 }}        
+                {{- toYaml .Values.resources | nindent 16 }}
 {{- end }}


### PR DESCRIPTION
CronJob has reached GA in Kubernetes 1.21.
Announcement: https://kubernetes.io/blog/2021/04/09/kubernetes-release-1.21-cronjob-ga/

Fixes #362