### PR TITLE
Add extraEnv and podLabels to helm chart deployment

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
+
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -22,6 +23,10 @@ spec:
       {{- end }}
       labels:
         {{- include "reflector.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -44,6 +49,10 @@ spec:
               value: {{ .Values.configuration.logging.minimumLevel | quote }}
             - name: ES_Reflector__Watcher__Timeout
               value: {{ .Values.configuration.watcher.timeout | quote }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           ports:
             - name: http
               containerPort: 25080

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -40,7 +40,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# additional annotations to set on the pod
 podAnnotations: {}
+# additional labels to set on the pod
+podLabels: {}
+# additional env vars to add to the pod
+extraEnv: []
 
 podSecurityContext:
   fsGroup: 2000


### PR DESCRIPTION
## What is this?

Adds `extraEnv` and `podLabels` as top-level values in the helm chart. This is useful for environments that require specific labels to be added to pods to facilitate log/metrics collection.

## Verification

I verified this renders properly by running the following, and verifying the labels and env vars are present and indented correctly.

```
kubernetes-reflector/src/helm/reflector $ helm template -f <(echo -e 'podLabels: { "foo":"bar" }\nextraEnv: [{name: "TEST", value: "example"}]') reflector ./
```

@sydorovdmytro
