### PR TITLE
bump docker base to debian bookworm

### DIFF
--- a/src/ES.Kubernetes.Reflector/Dockerfile
+++ b/src/ES.Kubernetes.Reflector/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 EXPOSE 25080
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim-amd64 AS build
 WORKDIR /src
 COPY ["ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj", "ES.Kubernetes.Reflector/"]
 RUN dotnet restore "ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj"


### PR DESCRIPTION
Currently Artifact Hub lists over 100 vulnerabilities for kubernetes-reflector.

The vulnerabilities are mostly about the Docker Base Debian 11 Image and technically don't affect kubernetes-reflector but it still gives a bad feeling and shows lack of maintenance.

I updated the Docker Base to use Debian 12 with the slim image, this should remove most vulnerabilities and also reduce the image size, this would result in a new major release `v8.0.0`, although it is backwards compatible.

Please review and test the changes.

![image](https://github.com/emberstack/kubernetes-reflector/assets/95883234/e3d6671b-b147-49c8-bfce-43353653b377)
