### PR TITLE
bump docker base to debian bookworm

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/**"
 
 env:
-  version: 7.0.${{github.run_number}}
+  version: 7.1.${{github.run_number}}
   imageRepository: "emberstack/kubernetes-reflector"
   DOCKER_CLI_EXPERIMENTAL: "enabled"
 

--- a/src/ES.Kubernetes.Reflector/Dockerfile
+++ b/src/ES.Kubernetes.Reflector/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 EXPOSE 25080
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim-amd64 AS build
 WORKDIR /src
 COPY ["ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj", "ES.Kubernetes.Reflector/"]
 RUN dotnet restore "ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj"


### PR DESCRIPTION
Currently Artifact Hub lists over 100 vulnerabilities for kubernetes-reflector.

The vulnerabilities are mostly about the Docker Base Debian 11 Image and technically don't affect kubernetes-reflector but it still gives a bad feeling and shows lack of maintenance.

I updated the Docker Base to use Debian 12 with the slim image, this should remove most vulnerabilities and also reduce the image size.

Please review and test the changes.

![image](https://github.com/emberstack/kubernetes-reflector/assets/95883234/b4b9a382-1005-4b4c-84a1-ca2245f9866e)
