### PR TITLE
feat: add support for more K8s resources

### DIFF
--- a/src/ES.Kubernetes.Reflector/Core/Mirroring/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/Mirroring/ResourceMirror.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+﻿﻿using System.Collections.Concurrent;
 using System.Net;
 using ES.Kubernetes.Reflector.Core.Extensions;
 using ES.Kubernetes.Reflector.Core.Json;
@@ -13,6 +13,7 @@ using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.JsonPatch.Operations;
 using Newtonsoft.Json;
+using CloudNimble.EasyAF.NewtonsoftJson.Compatibility;
 
 namespace ES.Kubernetes.Reflector.Core.Mirroring;
 
@@ -478,7 +479,7 @@ public abstract class ResourceMirror<TResource> :
 
             await OnResourceConfigurePatch(source, patchDoc);
 
-            var patch = JsonConvert.SerializeObject(patchDoc, Formatting.Indented);
+            var patch = JsonConvert.SerializeObject(patchDoc, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new SystemTextJsonContractResolver() });
             await OnResourceApplyPatch(new V1Patch(patch, V1Patch.PatchType.JsonPatch), targetId);
             Logger.LogInformation("Patched {id} as a reflection of {sourceId}", targetId, sourceId);
         }

--- a/src/ES.Kubernetes.Reflector/Core/RoleBindingMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/RoleBindingMirror.cs
@@ -1,0 +1,61 @@
+﻿using ES.Kubernetes.Reflector.Core.Mirroring;
+using ES.Kubernetes.Reflector.Core.Resources;
+using k8s;
+using k8s.Models;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Text.Json;
+using System.Diagnostics;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class RoleBindingMirror : ResourceMirror<V1RoleBinding>
+{
+    public RoleBindingMirror(ILogger<RoleBindingMirror> logger, IKubernetes client) : base(logger, client)
+    {
+    }
+
+    protected override async Task<V1RoleBinding[]> OnResourceWithNameList(string itemRefName)
+    {
+        return (await Client.RbacAuthorizationV1.ListRoleBindingForAllNamespacesAsync(fieldSelector: $"metadata.name={itemRefName}")).Items
+            .ToArray();
+    }
+
+    protected override Task OnResourceApplyPatch(V1Patch patch, KubeRef refId)
+    {
+        return Client.RbacAuthorizationV1.PatchNamespacedRoleBindingWithHttpMessagesAsync(patch, refId.Name, refId.Namespace);
+    }
+
+    protected override Task OnResourceConfigurePatch(V1RoleBinding source, JsonPatchDocument<V1RoleBinding> patchDoc)
+    {        
+        // Roleref is immutable by design, so we only patch the Subjects list
+        patchDoc.Replace(e => e.Subjects, source.Subjects);
+        return Task.CompletedTask;
+    }
+
+    protected override Task OnResourceCreate(V1RoleBinding item, string ns)
+    {
+        item.Metadata.ResourceVersion = null;
+        return Client.RbacAuthorizationV1.CreateNamespacedRoleBindingAsync(item, ns);
+    }
+
+    protected override Task<V1RoleBinding> OnResourceClone(V1RoleBinding sourceResource)
+    {
+        return Task.FromResult(new V1RoleBinding
+        {
+            ApiVersion = sourceResource.ApiVersion,
+            Kind = sourceResource.Kind,
+            Subjects = sourceResource.Subjects,
+            RoleRef = sourceResource.RoleRef
+        });
+    }
+
+    protected override Task OnResourceDelete(KubeRef resourceId)
+    {
+        return Client.RbacAuthorizationV1.DeleteNamespacedRoleBindingAsync(resourceId.Name, resourceId.Namespace);
+    }
+
+    protected override Task<V1RoleBinding> OnResourceGet(KubeRef refId)
+    {
+        return Client.RbacAuthorizationV1.ReadNamespacedRoleBindingAsync(refId.Name, refId.Namespace);
+    }
+}

--- a/src/ES.Kubernetes.Reflector/Core/RoleBindingWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/RoleBindingWatcher.cs
@@ -1,0 +1,24 @@
+using ES.Kubernetes.Reflector.Core.Configuration;
+using ES.Kubernetes.Reflector.Core.Watchers;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class RoleBindingWatcher : WatcherBackgroundService<V1RoleBinding, V1RoleBindingList>
+{
+    public RoleBindingWatcher(ILogger<RoleBindingWatcher> logger, IMediator mediator, IKubernetes client,
+        IOptionsMonitor<ReflectorOptions> options) :
+        base(logger, mediator, client, options)
+    {
+    }
+
+    protected override Task<HttpOperationResponse<V1RoleBindingList>> OnGetWatcher(CancellationToken cancellationToken)
+    {
+        return Client.RbacAuthorizationV1.ListRoleBindingForAllNamespacesWithHttpMessagesAsync(watch: true, timeoutSeconds: WatcherTimeout,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/ES.Kubernetes.Reflector/Core/RoleMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/RoleMirror.cs
@@ -1,0 +1,60 @@
+﻿using ES.Kubernetes.Reflector.Core.Mirroring;
+using ES.Kubernetes.Reflector.Core.Resources;
+using k8s;
+using k8s.Models;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Text.Json;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class RoleMirror : ResourceMirror<V1Role>
+{
+    public RoleMirror(ILogger<RoleMirror> logger, IKubernetes client) : base(logger, client)
+    {
+    }
+
+    protected override async Task<V1Role[]> OnResourceWithNameList(string itemRefName)
+    {
+        return (await Client.RbacAuthorizationV1.ListRoleForAllNamespacesAsync(fieldSelector: $"metadata.name={itemRefName}")).Items
+            .ToArray();
+    }
+
+    protected override Task OnResourceApplyPatch(V1Patch patch, KubeRef refId)
+    {
+        return Client.RbacAuthorizationV1.PatchNamespacedRoleWithHttpMessagesAsync(patch, refId.Name, refId.Namespace);
+    }
+
+    protected override Task OnResourceConfigurePatch(V1Role source, JsonPatchDocument<V1Role> patchDoc)
+    {
+        // Replace with new List of Rules
+        patchDoc.Replace(e => e.Rules, source.Rules);
+        return Task.CompletedTask;
+    }
+
+    protected override Task OnResourceCreate(V1Role item, string ns)
+    {
+        item.Metadata.ResourceVersion = null;
+        return Client.RbacAuthorizationV1.CreateNamespacedRoleAsync(item, ns);
+    }
+
+    protected override Task<V1Role> OnResourceClone(V1Role sourceResource)
+    {
+        return Task.FromResult(new V1Role
+        {
+            ApiVersion = sourceResource.ApiVersion,
+            Kind = sourceResource.Kind,
+            Rules = sourceResource.Rules
+        });
+    }
+
+    protected override Task OnResourceDelete(KubeRef resourceId)
+    {
+        return Client.RbacAuthorizationV1.DeleteNamespacedRoleAsync(resourceId.Name, resourceId.Namespace);
+    }
+
+    protected override Task<V1Role> OnResourceGet(KubeRef refId)
+    {
+        return Client.RbacAuthorizationV1.ReadNamespacedRoleAsync(refId.Name, refId.Namespace);
+    }
+
+}

--- a/src/ES.Kubernetes.Reflector/Core/RoleWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/RoleWatcher.cs
@@ -1,0 +1,24 @@
+using ES.Kubernetes.Reflector.Core.Configuration;
+using ES.Kubernetes.Reflector.Core.Watchers;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class RoleWatcher : WatcherBackgroundService<V1Role, V1RoleList>
+{
+    public RoleWatcher(ILogger<RoleWatcher> logger, IMediator mediator, IKubernetes client,
+        IOptionsMonitor<ReflectorOptions> options) :
+        base(logger, mediator, client, options)
+    {
+    }
+
+    protected override Task<HttpOperationResponse<V1RoleList>> OnGetWatcher(CancellationToken cancellationToken)
+    {
+        return Client.RbacAuthorizationV1.ListRoleForAllNamespacesWithHttpMessagesAsync(watch: true, timeoutSeconds: WatcherTimeout,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/ES.Kubernetes.Reflector/Core/ServiceAccountMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/ServiceAccountMirror.cs
@@ -1,0 +1,56 @@
+﻿using ES.Kubernetes.Reflector.Core.Mirroring;
+using ES.Kubernetes.Reflector.Core.Resources;
+using k8s;
+using k8s.Models;
+using Microsoft.AspNetCore.JsonPatch;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class ServiceAccountMirror : ResourceMirror<V1ServiceAccount>
+{
+    public ServiceAccountMirror(ILogger<ServiceAccountMirror> logger, IKubernetes client) : base(logger, client)
+    {
+    }
+
+    protected override async Task<V1ServiceAccount[]> OnResourceWithNameList(string itemRefName)
+    {
+        return (await Client.CoreV1.ListServiceAccountForAllNamespacesAsync(fieldSelector: $"metadata.name={itemRefName}")).Items
+            .ToArray();
+    }
+
+    protected override Task OnResourceApplyPatch(V1Patch patch, KubeRef refId)
+    {
+        return Client.CoreV1.PatchNamespacedServiceAccountWithHttpMessagesAsync(patch, refId.Name, refId.Namespace);
+    }
+
+    protected override Task OnResourceConfigurePatch(V1ServiceAccount source, JsonPatchDocument<V1ServiceAccount> patchDoc)
+    {
+        // Just update annotations.
+        return Task.CompletedTask;
+    }
+
+    protected override Task OnResourceCreate(V1ServiceAccount item, string ns)
+    {
+        item.Metadata.ResourceVersion = null;
+        return Client.CoreV1.CreateNamespacedServiceAccountAsync(item, ns);
+    }
+
+    protected override Task<V1ServiceAccount> OnResourceClone(V1ServiceAccount sourceResource)
+    {
+        return Task.FromResult(new V1ServiceAccount
+        {
+            ApiVersion = sourceResource.ApiVersion,
+            Kind = sourceResource.Kind
+        });
+    }
+
+    protected override Task OnResourceDelete(KubeRef resourceId)
+    {
+        return Client.CoreV1.DeleteNamespacedServiceAccountAsync(resourceId.Name, resourceId.Namespace);
+    }
+
+    protected override Task<V1ServiceAccount> OnResourceGet(KubeRef refId)
+    {
+        return Client.CoreV1.ReadNamespacedServiceAccountAsync(refId.Name, refId.Namespace);
+    }
+}

--- a/src/ES.Kubernetes.Reflector/Core/ServiceAccountWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/ServiceAccountWatcher.cs
@@ -1,0 +1,24 @@
+using ES.Kubernetes.Reflector.Core.Configuration;
+using ES.Kubernetes.Reflector.Core.Watchers;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace ES.Kubernetes.Reflector.Core;
+
+public class ServiceAccountWatcher : WatcherBackgroundService<V1ServiceAccount, V1ServiceAccountList>
+{
+    public ServiceAccountWatcher(ILogger<ServiceAccountWatcher> logger, IMediator mediator, IKubernetes client,
+        IOptionsMonitor<ReflectorOptions> options) :
+        base(logger, mediator, client, options)
+    {
+    }
+
+    protected override Task<HttpOperationResponse<V1ServiceAccountList>> OnGetWatcher(CancellationToken cancellationToken)
+    {
+        return Client.CoreV1.ListServiceAccountForAllNamespacesWithHttpMessagesAsync(watch: true, timeoutSeconds: WatcherTimeout,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj
+++ b/src/ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="EasyAF.NewtonsoftJson.Compatibility" Version="2.0.2" />
 		<PackageReference Include="KubernetesClient" Version="12.1.1" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />

--- a/src/ES.Kubernetes.Reflector/Program.cs
+++ b/src/ES.Kubernetes.Reflector/Program.cs
@@ -75,6 +75,15 @@ try
 
         container.RegisterType<ConfigMapWatcher>().AsImplementedInterfaces().SingleInstance();
         container.RegisterType<ConfigMapMirror>().AsImplementedInterfaces().SingleInstance();
+
+        container.RegisterType<ServiceAccountWatcher>().AsImplementedInterfaces().SingleInstance();
+        container.RegisterType<ServiceAccountMirror>().AsImplementedInterfaces().SingleInstance();
+
+        container.RegisterType<RoleWatcher>().AsImplementedInterfaces().SingleInstance();
+        container.RegisterType<RoleMirror>().AsImplementedInterfaces().SingleInstance();
+
+        container.RegisterType<RoleBindingWatcher>().AsImplementedInterfaces().SingleInstance();
+        container.RegisterType<RoleBindingMirror>().AsImplementedInterfaces().SingleInstance();
     });
 
     builder.WebHost.ConfigureKestrel(options => { options.ListenAnyIP(25080); });

--- a/src/helm/reflector/templates/NOTES.txt
+++ b/src/helm/reflector/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Reflector can now be used to perform automatic copy actions on secrets and configmaps.
+Reflector can now be used to perform automatic copy actions on secrets, configmaps, service accounts, roles and rolebindings.

--- a/src/helm/reflector/templates/clusterRole.yaml
+++ b/src/helm/reflector/templates/clusterRole.yaml
@@ -8,9 +8,12 @@ metadata:
     {{- include "reflector.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "secrets"]
+    resources: ["configmaps", "secrets", "serviceaccounts"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["watch", "list"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: [ "roles", "rolebindings"]
+    verbs: ["*"]
 {{- end }}


### PR DESCRIPTION
When we had to rotate our K8s secrets, Reflector really came in handy to propagate our changes across namespaces. Later, we felt the need to extend Reflector's functionalities for other resources. Currently, we added support for:
- Service Accounts;
- Roles;
- Role Bindings.

Note that we needed to add [EasyAF.NewtonsoftJson.Compatibility](https://www.nuget.org/packages/EasyAF.NewtonsoftJson.Compatibility) package due to serialization problems when applying patches to roles and rolebindings. This does not interfere with the already existing logic of secrets and configmaps.

Hope you appreciate these changes!