### PR TITLE
Add helm values to support topologySpreadConstraints

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -87,4 +87,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -102,4 +102,6 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 priorityClassName: ""


### PR DESCRIPTION
This change add ```topologySpreadConstraints``` support to the Helm chart.
