### PR TITLE
Add ability to reflect whitelisted labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
   
   - Add `reflector.v1.k8s.emberstack.com/reflection-allowed: "true"` to the resource annotations to permit reflection to mirrors.
   - Add `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "<list>"` to the resource annotations to permit reflection from only the list of comma separated namespaces or regular expressions. Note: If this annotation is omitted or is empty, all namespaces are allowed.
+  - Add `reflector.v1.k8s.emberstack.com/reflection-labels: "true"` to the resource annotations to permit reflection of labels to mirrors. Note: If this annotation is ommitted or empty no labels are mirrored.
+  - Add `reflector.v1.k8s.emberstack.com/reflection-labels-included: "<list>"` to the resource annotations to permit reflection of only the list of comma separated labels or regular expressions. Note: If this annotation is ommitted or empty all labels are reflected.
 
   #### Automatic mirror creation:
   Reflector can create mirrors with the same name in other namespaces automatically. The following annotations control if and how the mirrors are created:
@@ -107,6 +109,24 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "namespace-1,namespace-2,namespace-[0-9]*"
+  data:
+    ...
+  ```
+
+  Example source configmap with labels:
+   ```yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: source-config-map
+    labels:
+      emberstack.com/included-label: to-be-included
+      example.com/excluded-label: to-be-excluded
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "namespace-1,namespace-2,namespace-[0-9]*"
+      reflector.v1.k8s.emberstack.com/reflection-labels: "true"
+      reflector.v1.k8s.emberstack.com/reflection-labels-included: "emberstack\\.com/.*"
   data:
     ...
   ```

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/Annotations.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/Annotations.cs
@@ -1,4 +1,4 @@
-﻿namespace ES.Kubernetes.Reflector.Mirroring.Core;
+namespace ES.Kubernetes.Reflector.Mirroring.Core;
 
 public static class Annotations
 {
@@ -10,6 +10,8 @@ public static class Annotations
         public static string AllowedNamespaces => $"{Prefix}/reflection-allowed-namespaces";
         public static string AutoEnabled => $"{Prefix}/reflection-auto-enabled";
         public static string AutoNamespaces => $"{Prefix}/reflection-auto-namespaces";
+        public static string Labels => $"{Prefix}/reflection-labels";
+        public static string LabelsIncluded => $"{Prefix}/reflection-labels-included";
         public static string Reflects => $"{Prefix}/reflects";
 
 

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringProperties.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringProperties.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using ES.FX.KubernetesClient.Models;
 
 namespace ES.Kubernetes.Reflector.Mirroring.Core;
@@ -9,6 +9,8 @@ public class MirroringProperties
     public string AllowedNamespaces { get; set; } = string.Empty;
     public bool AutoEnabled { get; set; }
     public string AutoNamespaces { get; set; } = string.Empty;
+    public bool Labels { get; set; }
+    public string LabelsIncluded { get; set; } = string.Empty;
     public NamespacedName? Reflects { get; set; }
 
     public string ResourceVersion { get; set; } = string.Empty;

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
@@ -32,6 +32,14 @@ public static class MirroringPropertiesExtensions
                 ? autoNamespaces ?? string.Empty
                 : string.Empty,
 
+            Labels = metadata
+                .TryGetAnnotationValue(Annotations.Reflection.Labels, out bool labels) && labels,
+
+            LabelsIncluded = metadata
+                .TryGetAnnotationValue(Annotations.Reflection.LabelsIncluded, out string? labelsIncluded)
+                ? labelsIncluded ?? string.Empty
+                : string.Empty,
+
             Reflects = metadata
                 .TryGetAnnotationValue(Annotations.Reflection.Reflects, out string? metaReflects)
                 ? NamespacedName.TryParse(metaReflects, out var id) ? id : null
@@ -63,6 +71,8 @@ public static class MirroringPropertiesExtensions
         properties.CanBeReflectedToNamespace(ns) && properties.AutoEnabled &&
         PatternListMatch(properties.AutoNamespaces, ns);
 
+    public static bool CanLabelBeReflected(this MirroringProperties properties, string label) =>
+        properties.Labels && PatternListMatch(properties.LabelsIncluded, label);
 
     private static bool PatternListMatch(string patternList, string value)
     {


### PR DESCRIPTION
Following feature request https://github.com/emberstack/kubernetes-reflector/discussions/414 I added the option to have labels mirrored based on two new annotations, `<prefix>/reflection-labels` and `<prefix>/reflection-labels-included`.

By default the functionality stays exactly the same with just the content being mirrored. However, once `<prefix>/reflection-labels` is set to true the source labels will be included in the mirror. `<prefix>/reflection-labels-included` is a regex list like already used for namespace whitelisting which can be used to finely filter the labels to be mirrored, for example to only mirror labels prefixed with `example.com/`:
```yaml
annotations:
  reflector.v1.k8s.emberstack.com/reflection-labels: "true"
  reflector.v1.k8s.emberstack.com/reflection-labels-included: "example\\.com/.*"
```