### PR TITLE
fix: fixed mirroring not working

### DIFF
--- a/src/ES.Kubernetes.Reflector/Core/ConfigMapWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/ConfigMapWatcher.cs
@@ -11,14 +11,13 @@ namespace ES.Kubernetes.Reflector.Core;
 public class ConfigMapWatcher(
     ILogger<ConfigMapWatcher> logger,
     IMediator mediator,
-    IServiceProvider serviceProvider,
+    IKubernetes kubernetesClient,
     IOptionsMonitor<ReflectorOptions> options)
-    : WatcherBackgroundService<V1ConfigMap, V1ConfigMapList>(logger, mediator, serviceProvider, options)
+    : WatcherBackgroundService<V1ConfigMap, V1ConfigMapList>(logger, mediator, options)
 {
-    protected override Task<HttpOperationResponse<V1ConfigMapList>> OnGetWatcher(IKubernetes client,
-        CancellationToken cancellationToken)
+    protected override Task<HttpOperationResponse<V1ConfigMapList>> OnGetWatcher(CancellationToken cancellationToken)
     {
-        return client.CoreV1.ListConfigMapForAllNamespacesWithHttpMessagesAsync(watch: true,
+        return kubernetesClient.CoreV1.ListConfigMapForAllNamespacesWithHttpMessagesAsync(watch: true,
             timeoutSeconds: WatcherTimeout,
             cancellationToken: cancellationToken);
     }

--- a/src/ES.Kubernetes.Reflector/Core/NamespaceWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/NamespaceWatcher.cs
@@ -11,14 +11,13 @@ namespace ES.Kubernetes.Reflector.Core;
 public class NamespaceWatcher(
     ILogger<NamespaceWatcher> logger,
     IMediator mediator,
-    IServiceProvider serviceProvider,
+    IKubernetes kubernetesClient,
     IOptionsMonitor<ReflectorOptions> options)
-    : WatcherBackgroundService<V1Namespace, V1NamespaceList>(logger, mediator, serviceProvider, options)
+    : WatcherBackgroundService<V1Namespace, V1NamespaceList>(logger, mediator, options)
 {
-    protected override Task<HttpOperationResponse<V1NamespaceList>> OnGetWatcher(IKubernetes client,
-        CancellationToken cancellationToken)
+    protected override Task<HttpOperationResponse<V1NamespaceList>> OnGetWatcher(CancellationToken cancellationToken)
     {
-        return client.CoreV1.ListNamespaceWithHttpMessagesAsync(watch: true, timeoutSeconds: WatcherTimeout,
+        return kubernetesClient.CoreV1.ListNamespaceWithHttpMessagesAsync(watch: true, timeoutSeconds: WatcherTimeout,
             cancellationToken: cancellationToken);
     }
 }

--- a/src/ES.Kubernetes.Reflector/Core/SecretMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Core/SecretMirror.cs
@@ -6,24 +6,18 @@ using Microsoft.AspNetCore.JsonPatch;
 
 namespace ES.Kubernetes.Reflector.Core;
 
-public class SecretMirror(ILogger<SecretMirror> logger, IServiceProvider serviceProvider)
-    : ResourceMirror<V1Secret>(logger, serviceProvider)
+public class SecretMirror(ILogger<SecretMirror> logger, IKubernetes kubernetesClient)
+    : ResourceMirror<V1Secret>(logger, kubernetesClient)
 {
-    private readonly IServiceProvider _serviceProvider = serviceProvider;
-
     protected override async Task<V1Secret[]> OnResourceWithNameList(string itemRefName)
     {
-        using var client = _serviceProvider.GetRequiredService<IKubernetes>();
-        return (await client.CoreV1.ListSecretForAllNamespacesAsync(fieldSelector: $"metadata.name={itemRefName}"))
+        return (await KubernetesClient.CoreV1.ListSecretForAllNamespacesAsync(fieldSelector: $"metadata.name={itemRefName}"))
             .Items
             .ToArray();
     }
 
     protected override async Task OnResourceApplyPatch(V1Patch patch, KubeRef refId)
-    {
-        using var client = _serviceProvider.GetRequiredService<IKubernetes>();
-        await client.CoreV1.PatchNamespacedSecretWithHttpMessagesAsync(patch, refId.Name, refId.Namespace);
-    }
+        => await KubernetesClient.CoreV1.PatchNamespacedSecretWithHttpMessagesAsync(patch, refId.Name, refId.Namespace);
 
     protected override Task OnResourceConfigurePatch(V1Secret source, JsonPatchDocument<V1Secret> patchDoc)
     {
@@ -32,10 +26,7 @@ public class SecretMirror(ILogger<SecretMirror> logger, IServiceProvider service
     }
 
     protected override async Task OnResourceCreate(V1Secret item, string ns)
-    {
-        using var client = _serviceProvider.GetRequiredService<IKubernetes>();
-        await client.CoreV1.CreateNamespacedSecretAsync(item, ns);
-    }
+        => await KubernetesClient.CoreV1.CreateNamespacedSecretAsync(item, ns);
 
     protected override Task<V1Secret> OnResourceClone(V1Secret sourceResource)
     {
@@ -49,16 +40,10 @@ public class SecretMirror(ILogger<SecretMirror> logger, IServiceProvider service
     }
 
     protected override async Task OnResourceDelete(KubeRef resourceId)
-    {
-        using var client = _serviceProvider.GetRequiredService<IKubernetes>();
-        await client.CoreV1.DeleteNamespacedSecretAsync(resourceId.Name, resourceId.Namespace);
-    }
+        => await KubernetesClient.CoreV1.DeleteNamespacedSecretAsync(resourceId.Name, resourceId.Namespace);
 
     protected override async Task<V1Secret> OnResourceGet(KubeRef refId)
-    {
-        using var client = _serviceProvider.GetRequiredService<IKubernetes>();
-        return await client.CoreV1.ReadNamespacedSecretAsync(refId.Name, refId.Namespace);
-    }
+        => await KubernetesClient.CoreV1.ReadNamespacedSecretAsync(refId.Name, refId.Namespace);
 
     protected override Task<bool> OnResourceIgnoreCheck(V1Secret item)
     {

--- a/src/ES.Kubernetes.Reflector/Core/SecretWatcher.cs
+++ b/src/ES.Kubernetes.Reflector/Core/SecretWatcher.cs
@@ -11,14 +11,13 @@ namespace ES.Kubernetes.Reflector.Core;
 public class SecretWatcher(
     ILogger<SecretWatcher> logger,
     IMediator mediator,
-    IServiceProvider serviceProvider,
+    IKubernetes kubernetesClient,
     IOptionsMonitor<ReflectorOptions> options)
-    : WatcherBackgroundService<V1Secret, V1SecretList>(logger, mediator, serviceProvider, options)
+    : WatcherBackgroundService<V1Secret, V1SecretList>(logger, mediator, options)
 {
-    protected override Task<HttpOperationResponse<V1SecretList>> OnGetWatcher(IKubernetes client,
-        CancellationToken cancellationToken)
+    protected override Task<HttpOperationResponse<V1SecretList>> OnGetWatcher(CancellationToken cancellationToken)
     {
-        return client.CoreV1.ListSecretForAllNamespacesWithHttpMessagesAsync(watch: true,
+        return kubernetesClient.CoreV1.ListSecretForAllNamespacesWithHttpMessagesAsync(watch: true,
             timeoutSeconds: WatcherTimeout,
             cancellationToken: cancellationToken);
     }

--- a/src/ES.Kubernetes.Reflector/Program.cs
+++ b/src/ES.Kubernetes.Reflector/Program.cs
@@ -23,7 +23,7 @@ return await ProgramEntry.CreateBuilder(args).UseSerilog().Build().RunAsync(asyn
 
     builder.Services.Configure<ReflectorOptions>(builder.Configuration.GetSection(nameof(ES.Kubernetes.Reflector)));
 
-    builder.Services.AddTransient(s =>
+    builder.Services.AddSingleton(s =>
     {
         var reflectorOptions = s.GetRequiredService<IOptions<ReflectorOptions>>();
 
@@ -35,7 +35,7 @@ return await ProgramEntry.CreateBuilder(args).UseSerilog().Build().RunAsync(asyn
     });
 
 
-    builder.Services.AddTransient<IKubernetes>(s =>
+    builder.Services.AddSingleton<IKubernetes>(s =>
         new Kubernetes(s.GetRequiredService<KubernetesClientConfiguration>()));
 
     builder.Services.AddHostedService<NamespaceWatcher>();

--- a/src/ES.Kubernetes.Reflector/Program.cs
+++ b/src/ES.Kubernetes.Reflector/Program.cs
@@ -42,10 +42,6 @@ return await ProgramEntry.CreateBuilder(args).UseSerilog().Build().RunAsync(asyn
     builder.Services.AddHostedService<SecretWatcher>();
     builder.Services.AddHostedService<ConfigMapWatcher>();
 
-    builder.Services.AddSingleton<SecretMirror>();
-    builder.Services.AddSingleton<ConfigMapMirror>();
-
-
     var app = builder.Build();
     app.Ignite();
     await app.RunAsync();


### PR DESCRIPTION
Mirroring is currently broken in version v9.0.313, as reported here #478 

The issue is caused by a NullReferenceException in [ResourceMirror.cs#L328](https://github.com/emberstack/kubernetes-reflector/blob/f1e21835331c3ce7a5ae0879ec596451e9cb54ee/src/ES.Kubernetes.Reflector/Core/Mirroring/ResourceMirror.cs#L328). It seems like the client gets disposed.  There might be an issue with how service lifetimes and DI are managed.

@winromulus I was able to reproduce this issue through the integration tests I am currently writing. I will submit a separate PR for the tests.

Fixes: #478 
