### PR TITLE
test: add integration tests and CI pipeline updates

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -16,7 +16,7 @@ env:
   version: 9.0.${{github.run_number}}
   imageRepository: "emberstack/kubernetes-reflector"
   DOCKER_CLI_EXPERIMENTAL: "enabled"
-  DOTNET_VERSION: "9.x"
+  DOTNET_VERSION: "9.0.x"
 
 jobs:
   ci:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - "src/**"
+      - "tests/**"
       - ".github/workflows/**"
   pull_request:
     paths:
       - "src/**"
+      - "tests/**"
       - ".github/workflows/**"
 
 env:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -14,6 +14,7 @@ env:
   version: 9.0.${{github.run_number}}
   imageRepository: "emberstack/kubernetes-reflector"
   DOCKER_CLI_EXPERIMENTAL: "enabled"
+  DOTNET_VERSION: "9.x"
 
 jobs:
   ci:
@@ -21,6 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      
+      - name: Test
+        run: dotnet test -c Release --verbosity normal
+        working-directory: ./tests/ES.Kubernetes.Reflector.Tests
 
       - name: artifacts - prepare directories
         run: |

--- a/src/ES.Kubernetes.Reflector.sln
+++ b/src/ES.Kubernetes.Reflector.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "....Solution Items", "....S
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ES.Kubernetes.Reflector.Tests", "..\tests\ES.Kubernetes.Reflector.Tests\ES.Kubernetes.Reflector.Tests.csproj", "{19FBB55B-53C8-4EB1-9B76-34B69498E3A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,6 +24,10 @@ Global
 		{96CDE0CF-7782-490B-8AF6-4219DB0236B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96CDE0CF-7782-490B-8AF6-4219DB0236B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96CDE0CF-7782-490B-8AF6-4219DB0236B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19FBB55B-53C8-4EB1-9B76-34B69498E3A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19FBB55B-53C8-4EB1-9B76-34B69498E3A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19FBB55B-53C8-4EB1-9B76-34B69498E3A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19FBB55B-53C8-4EB1-9B76-34B69498E3A4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ES.Kubernetes.Reflector/Program.cs
+++ b/src/ES.Kubernetes.Reflector/Program.cs
@@ -40,3 +40,5 @@ return await ProgramEntry.CreateBuilder(args).UseSerilog().Build().RunAsync(asyn
     await app.RunAsync();
     return 0;
 });
+
+public partial class Program { }

--- a/tests/ES.Kubernetes.Reflector.Tests/BaseIntegrationTest.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/BaseIntegrationTest.cs
@@ -1,0 +1,99 @@
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Retry;
+using ES.FX.Ignite.Configuration;
+using k8s.Autorest;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public abstract class BaseIntegrationTest : IClassFixture<CustomWebApplicationFactory>
+{
+    protected readonly HttpClient Client;
+    protected readonly IKubernetes K8SClient;
+    protected readonly ResiliencePipeline<bool> Pipeline;
+    protected readonly IgniteSettings IgniteSettings;
+
+    protected BaseIntegrationTest(CustomWebApplicationFactory factory)
+    {
+        Client = factory.CreateClient();
+        var scope = factory.Services.CreateScope();
+        K8SClient = scope.ServiceProvider.GetRequiredService<IKubernetes>();
+        IgniteSettings = scope.ServiceProvider.GetRequiredService<IgniteSettings>();
+
+        // Polly retry and timeout policy to fetch replicated resources
+        Pipeline = new ResiliencePipelineBuilder<bool>()
+            .AddRetry(new RetryStrategyOptions<bool>
+            {
+                ShouldHandle = new PredicateBuilder<bool>()
+                    .Handle<HttpOperationException>(ex => 
+                        ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    .HandleResult(false),
+                MaxRetryAttempts = 5,
+                Delay = TimeSpan.FromSeconds(2),
+            })
+            .AddTimeout(TimeSpan.FromSeconds(30))
+            .Build();
+    }
+
+    protected async Task<V1Namespace?> CreateNamespaceAsync(string name)
+    {
+        var ns = new V1Namespace
+        {
+            ApiVersion = V1Namespace.KubeApiVersion,
+            Kind = V1Namespace.KubeKind,
+            Metadata = new V1ObjectMeta
+            {
+                Name = name
+            }
+        };
+
+         return await K8SClient.CoreV1.CreateNamespaceAsync(ns);
+    }
+
+    protected async Task<V1ConfigMap?> CreateConfigMapAsync(
+        string configMapName,
+        IDictionary<string, string> data,
+        string destinationNamespace,
+        ReflectorAnnotations reflectionAnnotations)
+    {
+        var configMap = new V1ConfigMap
+        {
+            ApiVersion = V1ConfigMap.KubeApiVersion,
+            Kind = V1ConfigMap.KubeKind,
+            Metadata = new V1ObjectMeta
+            {
+                Name = configMapName,
+                NamespaceProperty = destinationNamespace,
+                Annotations = reflectionAnnotations.Build()
+            },
+            Data = data
+        };
+        
+        return await K8SClient.CoreV1.CreateNamespacedConfigMapAsync(configMap, destinationNamespace);
+    }
+    
+    protected async Task<V1Secret?> CreateSecretAsync(
+        string secretName,
+        IDictionary<string, string> data,
+        string destinationNamespace,
+        ReflectorAnnotations reflectionAnnotations)
+    {
+        var secret = new V1Secret
+        {
+            ApiVersion = V1Secret.KubeApiVersion,
+            Kind = V1Secret.KubeKind,
+            Metadata = new V1ObjectMeta
+            {
+                Name = secretName,
+                NamespaceProperty = destinationNamespace,
+                Annotations = reflectionAnnotations.Build()
+            },
+            StringData = data,
+            Type = "Opaque"
+        };
+        
+        return await K8SClient.CoreV1.CreateNamespacedSecretAsync(secret, destinationNamespace);
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/ConfigMapMirrorTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/ConfigMapMirrorTests.cs
@@ -1,0 +1,85 @@
+using k8s;
+using Xunit.Abstractions;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class ConfigMapMirrorTests(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
+    : BaseIntegrationTest(factory)
+{
+    [Fact]
+    public async Task Create_configMap_With_ReflectionEnabled_Should_Replicated_To_Allowed_Namespaces()
+    {
+        // Arrange
+        const string sourceNamespace = "dev1";
+        const string destinationNamespace = "qa";
+        string sourceConfigMap = $"test-configmap-{Guid.NewGuid()}";
+        var configMapData = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+        var reflectorAnnotations = new ReflectorAnnotations()
+            .WithReflectionAllowed(true)
+            .WithAllowedNamespaces(destinationNamespace)
+            .WithAutoEnabled(true);
+
+        var createdSourceNs = await CreateNamespaceAsync(sourceNamespace);
+        createdSourceNs.ShouldBeCreated(sourceNamespace);
+        testOutputHelper.WriteLine($"Namespace {sourceNamespace} created");
+
+        // Act
+        var createdDestinationNs = await CreateNamespaceAsync(destinationNamespace);
+        createdDestinationNs.ShouldBeCreated(destinationNamespace);
+        testOutputHelper.WriteLine($"Namespace {destinationNamespace} created");
+        var createdConfigMap = await CreateConfigMapAsync(
+            sourceConfigMap,
+            configMapData,
+            sourceNamespace,
+            reflectorAnnotations);
+        createdConfigMap.ShouldBeCreated(sourceConfigMap);
+        testOutputHelper.WriteLine($"ConfigMap {sourceConfigMap} created in {sourceNamespace} namespace");
+
+        // Assert
+        await K8SClient.ShouldFindReplicatedResourceAsync(createdConfigMap, destinationNamespace, Pipeline);
+        testOutputHelper.WriteLine($"ConfigMap {sourceConfigMap} found in {destinationNamespace} namespace");
+    }
+
+    [Fact]
+    public async Task Create_configMap_With_DefaultReflectorAnnotations_Should_Replicated_To_All_Namespaces()
+    {
+        // Arrange
+        const string sourceNamespace = "dev2";
+        string sourceConfigMap = $"test-configmap-{Guid.NewGuid()}";
+        var configMapData = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+        var reflectorAnnotations = new ReflectorAnnotations();
+
+        var createdSourceNs = await CreateNamespaceAsync(sourceNamespace);
+        createdSourceNs.ShouldBeCreated(sourceNamespace);
+        testOutputHelper.WriteLine($"Namespace {sourceNamespace} created");
+
+        // Act
+        var createdConfigMap = await CreateConfigMapAsync(
+            sourceConfigMap,
+            configMapData,
+            sourceNamespace,
+            reflectorAnnotations);
+        createdConfigMap.ShouldBeCreated(sourceConfigMap);
+        testOutputHelper.WriteLine($"ConfigMap {sourceConfigMap} created in {sourceNamespace} namespace");
+
+        // Assert
+        var namespaces = await K8SClient.CoreV1.ListNamespaceAsync();
+        var targetNamespaces = namespaces.Items
+            .Where(ns => !string.Equals(ns.Metadata.Name, sourceNamespace, StringComparison.Ordinal))
+            .ToList();
+
+        await Task.WhenAll(targetNamespaces.Select(async ns =>
+        {
+            await K8SClient.ShouldFindReplicatedResourceAsync(createdConfigMap, ns.Metadata.Name, Pipeline);
+            testOutputHelper.WriteLine($"ConfigMap {sourceConfigMap} found in {ns.Metadata.Name} namespace");
+        }));
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/CustomWebApplicationFactory.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,76 @@
+using ES.Kubernetes.Reflector.Configuration;
+using k8s;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Testcontainers.K3s;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly K3sContainer _container = new K3sBuilder()
+        .WithImage("rancher/k3s:v1.26.2-k3s1")
+        .Build();
+    private static readonly Lock Lock = new();
+    
+    /// <summary>
+    /// https://github.com/serilog/serilog-aspnetcore/issues/289
+    /// https://github.com/dotnet/AspNetCore.Docs/issues/26609
+    /// There is a problem with using Serilog's "CreateBootstrapLogger" when trying to initialize a web host.
+    /// This is because in tests, multiple hosts are created in parallel, and Serilog's static logger is not thread-safe.
+    /// The way around this without touching the host code is to lock the creation of the host to a single thread at a time.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        lock (Lock)
+            return base.CreateHost(builder);
+    }
+    
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        var kubeConfigContent = _container.GetKubeconfigAsync().GetAwaiter().GetResult();
+        if (string.IsNullOrWhiteSpace(kubeConfigContent))
+        {
+            throw new InvalidOperationException("Kubeconfig content is empty");
+        }
+        
+        builder.ConfigureServices(services =>
+        {
+            //  remove the existing KubernetesClientConfiguration and IKubernetes registrations
+            var kubernetesClientConfiguration = services.SingleOrDefault(
+                d => d.ServiceType == typeof(KubernetesClientConfiguration));
+            if (kubernetesClientConfiguration is not null)
+            {
+                services.Remove(kubernetesClientConfiguration);
+            }
+            
+            services.AddSingleton(s =>
+            {
+                var reflectorOptions = s.GetRequiredService<IOptions<ReflectorOptions>>();
+
+                // create config file on disk file from _kubeConfigContent
+                var tempFile = Path.GetTempFileName();
+                File.WriteAllText(tempFile, kubeConfigContent);
+
+                var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(tempFile);
+                config.HttpClientTimeout = TimeSpan.FromMinutes(30);
+
+                return config;
+            });
+
+            services.AddSingleton<IKubernetes>(s =>
+                new k8s.Kubernetes(s.GetRequiredService<KubernetesClientConfiguration>()));
+        });
+    }
+
+    public Task InitializeAsync() 
+        => _container.StartAsync();
+
+    public new Task DisposeAsync() 
+        => _container.DisposeAsync().AsTask();
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/CustomWebApplicationFactory.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/CustomWebApplicationFactory.cs
@@ -16,15 +16,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         .Build();
     private static readonly Lock Lock = new();
     
-    /// <summary>
-    /// https://github.com/serilog/serilog-aspnetcore/issues/289
-    /// https://github.com/dotnet/AspNetCore.Docs/issues/26609
-    /// There is a problem with using Serilog's "CreateBootstrapLogger" when trying to initialize a web host.
-    /// This is because in tests, multiple hosts are created in parallel, and Serilog's static logger is not thread-safe.
-    /// The way around this without touching the host code is to lock the creation of the host to a single thread at a time.
-    /// </summary>
-    /// <param name="builder"></param>
-    /// <returns></returns>
+    // https://github.com/serilog/serilog-aspnetcore/issues/289
+    // https://github.com/dotnet/AspNetCore.Docs/issues/26609
     protected override IHost CreateHost(IHostBuilder builder)
     {
         lock (Lock)

--- a/tests/ES.Kubernetes.Reflector.Tests/ES.Kubernetes.Reflector.Tests.csproj
+++ b/tests/ES.Kubernetes.Reflector.Tests/ES.Kubernetes.Reflector.Tests.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/tests/ES.Kubernetes.Reflector.Tests/ES.Kubernetes.Reflector.Tests.csproj
+++ b/tests/ES.Kubernetes.Reflector.Tests/ES.Kubernetes.Reflector.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Polly.Core" Version="8.5.2" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="Testcontainers.K3s" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\ES.Kubernetes.Reflector\ES.Kubernetes.Reflector.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/ES.Kubernetes.Reflector.Tests/HealthCheckTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/HealthCheckTests.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using Shouldly;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class HealthCheckTests(CustomWebApplicationFactory factory) : BaseIntegrationTest(factory)
+{
+    [Fact]
+    public async Task LivenessHealthCheck_Should_Return_Healthy()
+    {
+        var response = await Client.GetAsync(IgniteSettings.HealthChecks.LivenessEndpointPath);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("text/plain");
+        var content = await response.Content.ReadAsStringAsync();
+        content.ShouldBe("Healthy");
+    }
+    
+    [Fact]
+    public async Task ReadinessHealthCheck_Should_Be_Unavailable()
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10));
+        var response = await Client.GetAsync(IgniteSettings.HealthChecks.ReadinessEndpointPath);
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/K8SResourceAssertionExtensions.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/K8SResourceAssertionExtensions.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics.CodeAnalysis;
+using k8s;
+using k8s.Models;
+using Polly;
+using Shouldly;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public static class K8SResourceAssertionExtensions
+{
+    public static void ShouldBeCreated<T>([NotNull] this T? resource, string metadataName)
+        where T : class, IKubernetesObject<V1ObjectMeta>
+    {
+        resource.ShouldNotBeNull();
+        resource.Metadata.ShouldNotBeNull();
+        resource.Metadata.Name.ShouldBe(metadataName);
+    }
+
+    public static void ShouldBeDeleted<T>([NotNull] this T resource, V1Status deletionStatus)
+        where T : class, IKubernetesObject<V1ObjectMeta>
+    {
+        resource.ShouldNotBeNull();
+        deletionStatus.ShouldNotBeNull();
+        deletionStatus.Status.ShouldBe("Success");
+    }
+
+
+    public static async Task ShouldFindReplicatedResourceAsync<T>(this IKubernetes client,
+        T resource,
+        string namespaceName,
+        ResiliencePipeline<bool> pipeline,
+        CancellationToken cancellationToken = default)
+        where T : class, IKubernetesObject<V1ObjectMeta>
+    {
+        var result =  await pipeline.ExecuteAsync(async token =>
+        {
+            IKubernetesObject<V1ObjectMeta>? retrievedResource = resource switch
+            {
+                V1ConfigMap => await client.CoreV1.ReadNamespacedConfigMapAsync(
+                    resource.Metadata.Name, 
+                    namespaceName,
+                    cancellationToken: token),
+                
+                V1Secret => await client.CoreV1.ReadNamespacedSecretAsync(
+                    resource.Metadata.Name,
+                    namespaceName,
+                    cancellationToken: token),
+                
+                _ => throw new NotSupportedException($"Resource type {typeof(T).Name} is not supported")
+            };
+
+            if (retrievedResource is null)
+                return false;
+
+            return (resource, retrievedResource) switch
+            {
+                (V1ConfigMap sourceConfigMap, V1ConfigMap replicatedConfigMap) => 
+                    sourceConfigMap.Data.IsEqualTo(replicatedConfigMap.Data),
+                
+                (V1Secret sourceSecret, V1Secret replicatedSecret) => 
+                    sourceSecret.Data.IsEqualTo(replicatedSecret.Data),
+                
+                _ => false
+            };
+        }, cancellationToken);
+        
+        result.ShouldBeTrue();
+    }
+    
+    private static bool IsEqualTo<TKey, TValue>(this IDictionary<TKey, TValue>? dict1, IDictionary<TKey, TValue>? dict2)
+        where TKey : notnull
+    {
+        if (dict1 == null && dict2 == null)
+            return true;
+
+        if (dict1 == null || dict2 == null)
+            return false;
+
+        if (dict1.Count != dict2.Count)
+            return false;
+
+        return dict1.All(kvp => dict2.TryGetValue(kvp.Key, out var value) && 
+                                AreValuesEqual(kvp.Value, value));
+    }
+
+    private static bool AreValuesEqual<TValue>(TValue value1, TValue value2)
+    {
+        if (value1 is byte[] bytes1 && value2 is byte[] bytes2)
+            return bytes1.SequenceEqual(bytes2);
+    
+        return EqualityComparer<TValue>.Default.Equals(value1, value2);
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/K8SResourceAssertionExtensions.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/K8SResourceAssertionExtensions.cs
@@ -15,16 +15,7 @@ public static class K8SResourceAssertionExtensions
         resource.Metadata.ShouldNotBeNull();
         resource.Metadata.Name.ShouldBe(metadataName);
     }
-
-    public static void ShouldBeDeleted<T>([NotNull] this T resource, V1Status deletionStatus)
-        where T : class, IKubernetesObject<V1ObjectMeta>
-    {
-        resource.ShouldNotBeNull();
-        deletionStatus.ShouldNotBeNull();
-        deletionStatus.Status.ShouldBe("Success");
-    }
-
-
+    
     public static async Task ShouldFindReplicatedResourceAsync<T>(this IKubernetes client,
         T resource,
         string namespaceName,

--- a/tests/ES.Kubernetes.Reflector.Tests/ReflectorAnnotations.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/ReflectorAnnotations.cs
@@ -1,0 +1,45 @@
+using ES.Kubernetes.Reflector.Mirroring.Core;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public sealed class ReflectorAnnotations
+{
+    private readonly Dictionary<string, string> _annotations = new();
+
+    public ReflectorAnnotations WithReflectionAllowed(bool allowed)
+    {
+        _annotations[Annotations.Reflection.Allowed] = allowed.ToString().ToLower();
+        return this;
+    }
+
+    public ReflectorAnnotations WithAllowedNamespaces(params string[] namespaces)
+    {
+        _annotations[Annotations.Reflection.AllowedNamespaces] = string.Join(",", namespaces);
+        return this;
+    }
+
+    public ReflectorAnnotations WithAutoEnabled(bool enabled)
+    {
+        _annotations[Annotations.Reflection.AutoEnabled] = enabled.ToString().ToLower();
+        return this;
+    }
+
+    public ReflectorAnnotations WithAutoNamespaces(bool enabled, params string[] namespaces)
+    {
+        _annotations[Annotations.Reflection.AutoNamespaces] = enabled ? string.Join(",", namespaces) : string.Empty;
+        return this;
+    }
+
+    public Dictionary<string, string> Build()
+    {
+        if (_annotations.Count == 0)
+        {
+            _annotations[Annotations.Reflection.Allowed] = "true";
+            _annotations[Annotations.Reflection.AllowedNamespaces] = string.Empty;
+            _annotations[Annotations.Reflection.AutoEnabled] = "true";
+            _annotations[Annotations.Reflection.AutoNamespaces] = string.Empty;
+        }
+        
+        return _annotations;
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/SecretMirrorTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/SecretMirrorTests.cs
@@ -1,0 +1,85 @@
+using k8s;
+using Xunit.Abstractions;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class SecretMirrorTests(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
+    : BaseIntegrationTest(factory)
+{
+    [Fact]
+    public async Task Create_secret_With_ReflectionEnabled_Should_Replicated_To_Allowed_Namespaces()
+    {
+        // Arrange
+        const string sourceNamespace = "dev002";
+        const string destinationNamespace = "qa002";
+        string sourceSecret = $"test-secret-{Guid.NewGuid()}";
+        var secretData = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+        var reflectorAnnotations = new ReflectorAnnotations()
+            .WithReflectionAllowed(true)
+            .WithAllowedNamespaces(destinationNamespace)
+            .WithAutoEnabled(true);
+
+        var createdSourceNs = await CreateNamespaceAsync(sourceNamespace);
+        createdSourceNs.ShouldBeCreated(sourceNamespace);
+        testOutputHelper.WriteLine($"Namespace {sourceNamespace} created");
+
+        // Act
+        var createdDestinationNs = await CreateNamespaceAsync(destinationNamespace);
+        createdDestinationNs.ShouldBeCreated(destinationNamespace);
+        testOutputHelper.WriteLine($"Namespace {destinationNamespace} created");
+        var createdSecret = await CreateSecretAsync(
+            sourceSecret,
+            secretData,
+            sourceNamespace,
+            reflectorAnnotations);
+        createdSecret.ShouldBeCreated(sourceSecret);
+        testOutputHelper.WriteLine($"Secret {sourceSecret} created in {sourceNamespace} namespace");
+
+        // Assert
+        await K8SClient.ShouldFindReplicatedResourceAsync(createdSecret, destinationNamespace, Pipeline);
+        testOutputHelper.WriteLine($"Secret {sourceSecret} found in {destinationNamespace} namespace");
+    }
+    
+    [Fact]
+    public async Task Create_secret_With_DefaultReflectorAnnotations_Should_Replicated_To_All_Namespaces()
+    {
+        // Arrange
+        const string sourceNamespace = "dev003";
+        string sourceSecret = $"test-secret-{Guid.NewGuid()}";
+        var secretData = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+        var reflectorAnnotations = new ReflectorAnnotations();
+
+        var createdSourceNs = await CreateNamespaceAsync(sourceNamespace);
+        createdSourceNs.ShouldBeCreated(sourceNamespace);
+        testOutputHelper.WriteLine($"Namespace {sourceNamespace} created");
+        
+        // Act
+        var createdSecret = await CreateSecretAsync(
+            sourceSecret,
+            secretData,
+            sourceNamespace,
+            reflectorAnnotations);
+        createdSecret.ShouldBeCreated(sourceSecret);
+        testOutputHelper.WriteLine($"Secret {sourceSecret} created in {sourceNamespace} namespace");
+        
+        // Assert
+        var namespaces = await K8SClient.CoreV1.ListNamespaceAsync();
+        var targetNamespaces = namespaces.Items
+            .Where(ns => !string.Equals(ns.Metadata.Name, sourceNamespace, StringComparison.Ordinal))
+            .ToList();
+        await Task.WhenAll(targetNamespaces.Select(async ns =>
+        {
+            await K8SClient.ShouldFindReplicatedResourceAsync(createdSecret, ns.Metadata.Name, Pipeline);
+            testOutputHelper.WriteLine($"Secret {sourceSecret} found in {ns.Metadata.Name} namespace");
+        }));
+    }
+    
+} 

--- a/tests/ES.Kubernetes.Reflector.Tests/SecretMirrorTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/SecretMirrorTests.cs
@@ -82,9 +82,8 @@ public class SecretMirrorTests(CustomWebApplicationFactory factory, ITestOutputH
         }));
     }
     
-    
     [Fact]
-    public async Task Create_secret_With_ReflectionEnabled_Should_Replicated_To_Newly_Created_Namespaces()
+    public async Task Create_secret_With_DefaultReflectorAnnotations_Should_Replicated_To_All_Newly_Created_Namespaces()
     {
         // Arrange
         const string sourceNamespace = "dev004";


### PR DESCRIPTION
This PR introduces integration tests, as discussed in [this conversation](https://github.com/emberstack/kubernetes-reflector/pull/479#issue-2889124686). The tests are structured to be easily extensible for future additions.

✅ All tests passed except for `Create_secret_With_DefaultReflectorAnnotations_Should_Replicated_To_All_Newly_Created_Namespaces`, which reproduces the issue reported in [#478](https://github.com/emberstack/kubernetes-reflector/issues/478).

Additionally, I have integrated the test execution step into the CI pipeline to ensure automated validation in future updates.
Let me know if you have any feedback @winromulus :)