### PR TITLE
Delete the reflected object

### DIFF
--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -84,7 +84,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                                 {
                                     Logger.LogDebug("Deleting {objNsName} - Source {sourceNsName} has been deleted",
                                         reflectionNsName, objNsName);
-                                    await OnResourceDelete(objNsName);
+                                    await OnResourceDelete(reflectionNsName);
                                 }
 
                             _autoSources.Remove(objNsName, out _);


### PR DESCRIPTION
This was mistakenly attempting to delete the source object instead of the reflected object.