### PR TITLE
refactor: delete info isn't allowed reflection-auto-namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
   #### Automatic mirror creation:
   Reflector can create mirrors with the same name in other namespaces automatically. The following annotations control if and how the mirrors are created:
   - Add `reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"` to the resource annotations to automatically create mirrors in other namespaces. Note: Requires `reflector.v1.k8s.emberstack.com/reflection-allowed` to be `true` since mirrors need to able to reflect the source.
-  - Add `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "<list>"` to the resource annotations specify in which namespaces to automatically create mirrors. Note: If this annotation is omitted or is empty, all namespaces are allowed. Namespaces in this list will also be checked by `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces` since mirrors need to be in namespaces from where reflection is permitted.
+  - Add `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "<list>"` to the resource annotations specify in which namespaces to automatically create mirrors. Namespaces in this list will also be checked by `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces` since mirrors need to be in namespaces from where reflection is permitted.
 
   > Important: If the `source` is deleted, automatic mirrors are deleted. Also if either reflection or automirroring is turned off or the automatic mirror's namespace is no longer a valid match for the allowed namespaces, the automatic mirror is deleted.
 


### PR DESCRIPTION
Following a test I noticed that the annotation is mandatory for sharing secrets between namespaces `reflection-auto-namespaces`

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: xxx-docker-creds
  namespace: whatever
  annotations:
    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "*"
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: "redacted"
 ``` 

```
 kubectl logs -l app.kubernetes.io/name=reflector -n reflector
2025-06-28 18:59:49.701 +00:00 [INF] (ES.Kubernetes.Reflector.Watchers.NamespaceWatcher) Requesting V1Namespace resources
2025-06-28 18:59:49.733 +00:00 [INF] (ES.Kubernetes.Reflector.Watchers.SecretWatcher) Requesting V1Secret resources
2025-06-28 18:59:49.762 +00:00 [INF] (ES.Kubernetes.Reflector.Watchers.ConfigMapWatcher) Requesting V1ConfigMap resources
2025-06-28 18:59:49.787 +00:00 [INF] (Microsoft.Hosting.Lifetime) Now listening on: http://[::]:8080
2025-06-28 18:59:49.787 +00:00 [INF] (Microsoft.Hosting.Lifetime) Application started. Press Ctrl+C to shut down.
2025-06-28 18:59:49.787 +00:00 [INF] (Microsoft.Hosting.Lifetime) Hosting environment: Production
2025-06-28 18:59:49.787 +00:00 [INF] (Microsoft.Hosting.Lifetime) Content root path: /app
```