### PR TITLE
helm:  cronjob securityContext for both pod and container

### DIFF
--- a/src/helm/reflector/templates/cron.yaml
+++ b/src/helm/reflector/templates/cron.yaml
@@ -53,7 +53,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
 
-          {{- with .Values.cron.securityContext }}
+          {{- with .Values.cron.podSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -63,6 +63,10 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- with .Values.cron.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 18 }}
+              {{- end }}
               env:
                 - name: ES_Serilog__MinimumLevel__Default
                   value: {{ .Values.configuration.logging.minimumLevel | quote }}

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -19,7 +19,7 @@ cron:
   enabled: false
   schedule: "*/15 * * * *"
   activeDeadlineSeconds: 600
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1000
 


### PR DESCRIPTION
When running in a restricted context, it is impossible to deploy with helm, due to securityContext not defined.

Example namespace :

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: reflector
  labels:
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/warn: restricted
```

With current version, cron pod will not be created. With updated chart, you can define both pod and container securityContext to allow pod creation.