### PR TITLE
Add namespace label selector support for reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
   
   - Add `reflector.v1.k8s.emberstack.com/reflection-allowed: "true"` to the resource annotations to permit reflection to mirrors.
   - Add `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "<list>"` to the resource annotations to permit reflection from only the list of comma separated namespaces or regular expressions. Note: If this annotation is omitted or is empty, all namespaces are allowed.
+  - Add `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces-selector: "<selector>"` to the resource annotations to permit reflection only to namespaces matching the given Kubernetes label selector (e.g. `env=production`, `team in (a,b)`). If both this and `reflection-allowed-namespaces` are set, a namespace matches if it satisfies either condition.
 
   #### Automatic mirror creation:
   Reflector can create mirrors with the same name in other namespaces automatically. The following annotations control if and how the mirrors are created:
   - Add `reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"` to the resource annotations to automatically create mirrors in other namespaces. Note: Requires `reflector.v1.k8s.emberstack.com/reflection-allowed` to be `true` since mirrors need to able to reflect the source.
   - Add `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "<list>"` to the resource annotations specify in which namespaces to automatically create mirrors. Note: If this annotation is omitted or is empty, all namespaces are allowed. Namespaces in this list will also be checked by `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces` since mirrors need to be in namespaces from where reflection is permitted.
+  - Add `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces-selector: "<selector>"` to the resource annotations to select namespaces for automatic mirrors using a Kubernetes label selector. If both this and `reflection-auto-namespaces` are set, a namespace matches if it satisfies either condition.
 
   > Important: If the `source` is deleted, automatic mirrors are deleted. Also if either reflection or automirroring is turned off or the automatic mirror's namespace is no longer a valid match for the allowed namespaces, the automatic mirror is deleted.
 
@@ -98,10 +100,11 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "namespace-1,namespace-2,namespace-[0-9]*"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces-selector: "env=production"
   data:
     ...
   ```
-  
+
   Example source configmap:
    ```yaml
   apiVersion: v1
@@ -111,10 +114,11 @@ $ kubectl -n kube-system apply -f https://github.com/emberstack/kubernetes-refle
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "namespace-1,namespace-2,namespace-[0-9]*"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces-selector: "env=production"
   data:
     ...
   ```
-  
+
 ### 2. Annotate the mirror secret or configmap
 
   - Add `reflector.v1.k8s.emberstack.com/reflects: "<source namespace>/<source name>"` to the mirror object. The value of the annotation is the full name of the source object in `namespace/name` format.

--- a/src/ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj
+++ b/src/ES.Kubernetes.Reflector/ES.Kubernetes.Reflector.csproj
@@ -9,6 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="ES.Kubernetes.Reflector.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="ES.FX.Ignite" />
 		<PackageReference Include="ES.FX.Ignite.OpenTelemetry.Exporter.Seq" />
 		<PackageReference Include="ES.FX.Ignite.Serilog" />

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/Annotations.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/Annotations.cs
@@ -8,8 +8,10 @@ public static class Annotations
     {
         public static string Allowed => $"{Prefix}/reflection-allowed";
         public static string AllowedNamespaces => $"{Prefix}/reflection-allowed-namespaces";
+        public static string AllowedNamespacesSelector => $"{Prefix}/reflection-allowed-namespaces-selector";
         public static string AutoEnabled => $"{Prefix}/reflection-auto-enabled";
         public static string AutoNamespaces => $"{Prefix}/reflection-auto-namespaces";
+        public static string AutoNamespacesSelector => $"{Prefix}/reflection-auto-namespaces-selector";
         public static string Reflects => $"{Prefix}/reflects";
 
 

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringProperties.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringProperties.cs
@@ -7,8 +7,10 @@ public class MirroringProperties
 {
     public bool Allowed { get; set; }
     public string AllowedNamespaces { get; set; } = string.Empty;
+    public string AllowedNamespacesSelector { get; set; } = string.Empty;
     public bool AutoEnabled { get; set; }
     public string AutoNamespaces { get; set; } = string.Empty;
+    public string AutoNamespacesSelector { get; set; } = string.Empty;
     public NamespacedName? Reflects { get; set; }
 
     public string ResourceVersion { get; set; } = string.Empty;

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
@@ -127,7 +127,7 @@ public static class MirroringPropertiesExtensions
 
     /// <summary>
     ///     Matches a Kubernetes label selector string against namespace labels.
-    ///     Supports equality-based (=, ==, !=) and existence-based (key, !key) selectors.
+    ///     Supports equality-based (=, ==, !=), set-based (in, notin), and existence-based (key, !key) selectors.
     ///     Multiple selectors separated by commas are ANDed together.
     /// </summary>
     internal static bool LabelSelectorMatch(string selector, V1Namespace ns)

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using ES.FX.Additions.KubernetesClient.Models;
 using ES.FX.Additions.KubernetesClient.Models.Extensions;
 using k8s;
@@ -24,12 +24,24 @@ public static class MirroringPropertiesExtensions
                 ? allowedNamespaces ?? string.Empty
                 : string.Empty,
 
+            AllowedNamespacesSelector = metadata
+                .TryGetAnnotationValue(Annotations.Reflection.AllowedNamespacesSelector,
+                    out string? allowedNamespacesSelector)
+                ? allowedNamespacesSelector ?? string.Empty
+                : string.Empty,
+
             AutoEnabled = metadata
                 .TryGetAnnotationValue(Annotations.Reflection.AutoEnabled, out bool autoEnabled) && autoEnabled,
 
             AutoNamespaces = metadata
                 .TryGetAnnotationValue(Annotations.Reflection.AutoNamespaces, out string? autoNamespaces)
                 ? autoNamespaces ?? string.Empty
+                : string.Empty,
+
+            AutoNamespacesSelector = metadata
+                .TryGetAnnotationValue(Annotations.Reflection.AutoNamespacesSelector,
+                    out string? autoNamespacesSelector)
+                ? autoNamespacesSelector ?? string.Empty
                 : string.Empty,
 
             Reflects = metadata
@@ -55,14 +67,54 @@ public static class MirroringPropertiesExtensions
                 : null
         };
 
+    /// <summary>
+    ///     Checks if the source properties allow reflection to the given namespace (by name only).
+    ///     Use the overload accepting V1Namespace for label selector support.
+    /// </summary>
     public static bool CanBeReflectedToNamespace(this MirroringProperties properties, string ns) =>
         properties.Allowed && PatternListMatch(properties.AllowedNamespaces, ns);
 
+    /// <summary>
+    ///     Checks if the source properties allow reflection to the given namespace,
+    ///     including label selector matching when a V1Namespace object is available.
+    /// </summary>
+    public static bool CanBeReflectedToNamespace(this MirroringProperties properties, V1Namespace ns) =>
+        properties.Allowed && MatchNamespace(properties.AllowedNamespaces, properties.AllowedNamespacesSelector, ns);
 
+    /// <summary>
+    ///     Checks if the source properties allow auto-reflection to the given namespace (by name only).
+    ///     Use the overload accepting V1Namespace for label selector support.
+    /// </summary>
     public static bool CanBeAutoReflectedToNamespace(this MirroringProperties properties, string ns) =>
         properties.CanBeReflectedToNamespace(ns) && properties.AutoEnabled &&
         PatternListMatch(properties.AutoNamespaces, ns);
 
+    /// <summary>
+    ///     Checks if the source properties allow auto-reflection to the given namespace,
+    ///     including label selector matching when a V1Namespace object is available.
+    /// </summary>
+    public static bool CanBeAutoReflectedToNamespace(this MirroringProperties properties, V1Namespace ns) =>
+        properties.CanBeReflectedToNamespace(ns) && properties.AutoEnabled &&
+        MatchNamespace(properties.AutoNamespaces, properties.AutoNamespacesSelector, ns);
+
+    /// <summary>
+    ///     Returns true if the namespace matches either the name pattern list or the label selector (OR logic).
+    ///     If both are empty, returns true (allow all).
+    /// </summary>
+    private static bool MatchNamespace(string patternList, string labelSelector, V1Namespace ns)
+    {
+        var hasPatterns = !string.IsNullOrEmpty(patternList);
+        var hasSelector = !string.IsNullOrEmpty(labelSelector);
+
+        // If neither is set, allow all (same as existing behavior)
+        if (!hasPatterns && !hasSelector) return true;
+
+        // OR logic: match if either the name pattern or label selector matches
+        if (hasPatterns && PatternListMatch(patternList, ns.Name())) return true;
+        if (hasSelector && LabelSelectorMatch(labelSelector, ns)) return true;
+
+        return false;
+    }
 
     private static bool PatternListMatch(string patternList, string value)
     {
@@ -71,5 +123,115 @@ public static class MirroringPropertiesExtensions
         return regexPatterns.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim())
             .Select(pattern => Regex.Match(value, pattern))
             .Any(match => match.Success && match.Value.Length == value.Length);
+    }
+
+    /// <summary>
+    ///     Matches a Kubernetes label selector string against namespace labels.
+    ///     Supports equality-based (=, ==, !=) and existence-based (key, !key) selectors.
+    ///     Multiple selectors separated by commas are ANDed together.
+    /// </summary>
+    internal static bool LabelSelectorMatch(string selector, V1Namespace ns)
+    {
+        if (string.IsNullOrWhiteSpace(selector)) return true;
+
+        var labels = ns.Metadata?.Labels ?? new Dictionary<string, string>();
+        var requirements = SplitRequirements(selector);
+
+        foreach (var raw in requirements)
+        {
+            var requirement = raw.Trim();
+            if (string.IsNullOrEmpty(requirement)) continue;
+
+            // Handle set-based: key in (v1,v2) / key notin (v1,v2)
+            if (TryParseSetBased(requirement, labels, out var setResult))
+            {
+                if (!setResult) return false;
+                continue;
+            }
+
+            // Handle != (must check before =)
+            if (requirement.Contains("!="))
+            {
+                var parts = requirement.Split("!=", 2);
+                var key = parts[0].Trim();
+                var value = parts[1].Trim();
+                if (labels.TryGetValue(key, out var labelValue) && labelValue == value) return false;
+                continue;
+            }
+
+            // Handle == or =
+            var eqIndex = requirement.IndexOf("==", StringComparison.Ordinal);
+            if (eqIndex < 0) eqIndex = requirement.IndexOf('=');
+            if (eqIndex > 0)
+            {
+                var key = requirement[..eqIndex].TrimEnd('=').Trim();
+                var value = requirement[(eqIndex + (requirement[eqIndex..].StartsWith("==") ? 2 : 1))..].Trim();
+                if (!labels.TryGetValue(key, out var labelValue) || labelValue != value) return false;
+                continue;
+            }
+
+            // Handle !key (not exists)
+            if (requirement.StartsWith('!'))
+            {
+                var key = requirement[1..].Trim();
+                if (labels.ContainsKey(key)) return false;
+                continue;
+            }
+
+            // Handle key (exists)
+            if (!labels.ContainsKey(requirement)) return false;
+        }
+
+        return true;
+    }
+
+    private static List<string> SplitRequirements(string selector)
+    {
+        var results = new List<string>();
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < selector.Length; i++)
+        {
+            switch (selector[i])
+            {
+                case '(': depth++; break;
+                case ')': depth--; break;
+                case ',' when depth == 0:
+                    var part = selector[start..i].Trim();
+                    if (part.Length > 0) results.Add(part);
+                    start = i + 1;
+                    break;
+            }
+        }
+        var last = selector[start..].Trim();
+        if (last.Length > 0) results.Add(last);
+        return results;
+    }
+
+    private static bool TryParseSetBased(string requirement, IDictionary<string, string> labels, out bool result)
+    {
+        result = false;
+
+        // Match "key in (v1,v2)" or "key notin (v1,v2)"
+        var match = Regex.Match(requirement, @"^([a-zA-Z0-9_./-]+)\s+(in|notin)\s+\(([^)]*)\)$");
+        if (!match.Success) return false;
+
+        var key = match.Groups[1].Value;
+        var op = match.Groups[2].Value;
+        var values = match.Groups[3].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(v => v.Trim())
+            .ToHashSet();
+
+        labels.TryGetValue(key, out var labelValue);
+
+        result = op switch
+        {
+            "in" => labelValue != null && values.Contains(labelValue),
+            "notin" => labelValue == null || !values.Contains(labelValue),
+            _ => false
+        };
+
+        return true;
     }
 }

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
@@ -8,6 +8,26 @@ namespace ES.Kubernetes.Reflector.Mirroring.Core;
 
 public static class MirroringPropertiesExtensions
 {
+    // Kubernetes label name: 1-63 chars, alphanumeric plus _ . -, must start/end alphanumeric.
+    private static readonly Regex LabelNameRegex = new(
+        @"^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$",
+        RegexOptions.Compiled);
+
+    // Kubernetes label key prefix: DNS subdomain (lowercase alphanumeric and -, period-separated labels).
+    private static readonly Regex LabelPrefixRegex = new(
+        @"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$",
+        RegexOptions.Compiled);
+
+    // Kubernetes label value: up to 63 chars, same character rules as the name (empty values are allowed).
+    private static readonly Regex LabelValueRegex = new(
+        @"^([A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?)?$",
+        RegexOptions.Compiled);
+
+    // Matches "<key> in (<values>)" or "<key> notin (<values>)" at the requirement level.
+    private static readonly Regex SetBasedRequirementRegex = new(
+        @"^(?<key>\S+)\s+(?<op>in|notin)\s*\((?<values>[^)]*)\)$",
+        RegexOptions.Compiled);
+
     public static MirroringProperties GetMirroringProperties(this IKubernetesObject<V1ObjectMeta> resource) =>
         resource.EnsureMetadata().GetMirroringProperties();
 
@@ -98,6 +118,23 @@ public static class MirroringPropertiesExtensions
         MatchNamespace(properties.AutoNamespaces, properties.AutoNamespacesSelector, ns);
 
     /// <summary>
+    ///     Parses the label selector annotations on this properties instance and returns a list of parse errors,
+    ///     one per malformed selector. Returns an empty list if all selectors are valid (or unset). Callers can
+    ///     surface these errors so operators get feedback about misconfigured annotations.
+    /// </summary>
+    public static IReadOnlyList<string> GetLabelSelectorErrors(this MirroringProperties properties)
+    {
+        var errors = new List<string>();
+        CollectLabelSelectorErrors(
+            Annotations.Reflection.AllowedNamespacesSelector,
+            properties.AllowedNamespacesSelector, errors);
+        CollectLabelSelectorErrors(
+            Annotations.Reflection.AutoNamespacesSelector,
+            properties.AutoNamespacesSelector, errors);
+        return errors;
+    }
+
+    /// <summary>
     ///     Returns true if the namespace matches either the name pattern list or the label selector (OR logic).
     ///     If both are empty, returns true (allow all).
     /// </summary>
@@ -128,67 +165,122 @@ public static class MirroringPropertiesExtensions
     /// <summary>
     ///     Matches a Kubernetes label selector string against namespace labels.
     ///     Supports equality-based (=, ==, !=), set-based (in, notin), and existence-based (key, !key) selectors.
-    ///     Multiple selectors separated by commas are ANDed together.
+    ///     Multiple selectors separated by commas are ANDed together. Invalid selectors fail closed (return false).
     /// </summary>
     internal static bool LabelSelectorMatch(string selector, V1Namespace ns)
     {
         if (string.IsNullOrWhiteSpace(selector)) return true;
 
+        if (!TryParseLabelSelector(selector, out var parsed, out _))
+            return false;
+
         var labels = ns.Metadata?.Labels ?? new Dictionary<string, string>();
-        var requirements = SplitRequirements(selector);
+        return MatchesLabels(parsed, labels);
+    }
 
-        // Fail closed: a non-empty selector that produces no valid requirements is invalid
-        if (requirements.Count == 0) return false;
+    /// <summary>
+    ///     Parses a Kubernetes label selector string into a <see cref="V1LabelSelector" />. Returns false if the
+    ///     selector is malformed; <paramref name="errors" /> lists the reasons. An empty or whitespace selector
+    ///     parses successfully into an empty selector (matches everything).
+    /// </summary>
+    internal static bool TryParseLabelSelector(string raw, out V1LabelSelector selector,
+        out IReadOnlyList<string> errors)
+    {
+        selector = new V1LabelSelector();
+        var errorList = new List<string>();
+        errors = errorList;
 
-        foreach (var raw in requirements)
+        if (string.IsNullOrWhiteSpace(raw)) return true;
+
+        var requirements = SplitRequirements(raw);
+        if (requirements.Count == 0)
         {
-            var requirement = raw.Trim();
-            if (string.IsNullOrEmpty(requirement)) continue;
+            errorList.Add("selector is not empty but contains no requirements");
+            return false;
+        }
 
-            // Handle set-based: key in (v1,v2) / key notin (v1,v2)
-            if (TryParseSetBased(requirement, labels, out var setResult))
+        var matchLabels = new Dictionary<string, string>();
+        var matchExpressions = new List<V1LabelSelectorRequirement>();
+
+        foreach (var requirement in requirements)
+        {
+            if (TryParseSetBased(requirement, out var setRequirement, out var setError))
             {
-                if (!setResult) return false;
+                if (setError != null) errorList.Add(setError);
+                else matchExpressions.Add(setRequirement!);
                 continue;
             }
 
-            // Handle != (must check before =)
-            if (requirement.Contains("!="))
+            if (TryParseInequality(requirement, errorList, out var neqRequirement))
             {
-                var parts = requirement.Split("!=", 2);
-                var key = parts[0].Trim();
-                if (string.IsNullOrEmpty(key)) return false;
-                var value = parts[1].Trim();
-                if (labels.TryGetValue(key, out var labelValue) && labelValue == value) return false;
+                if (neqRequirement != null) matchExpressions.Add(neqRequirement);
                 continue;
             }
 
-            // Handle == or =
-            var eqIndex = requirement.IndexOf("==", StringComparison.Ordinal);
-            if (eqIndex < 0) eqIndex = requirement.IndexOf('=');
-            if (eqIndex > 0)
+            if (TryParseEquality(requirement, errorList, matchLabels)) continue;
+
+            if (TryParseExistence(requirement, errorList, out var existRequirement))
             {
-                var key = requirement[..eqIndex].TrimEnd('=').Trim();
-                if (string.IsNullOrEmpty(key)) return false;
-                var value = requirement[(eqIndex + (requirement[eqIndex..].StartsWith("==") ? 2 : 1))..].Trim();
-                if (!labels.TryGetValue(key, out var labelValue) || labelValue != value) return false;
+                if (existRequirement != null) matchExpressions.Add(existRequirement);
                 continue;
             }
 
-            // Handle !key (not exists)
-            if (requirement.StartsWith('!'))
-            {
-                var key = requirement[1..].Trim();
-                if (string.IsNullOrEmpty(key)) return false;
-                if (labels.ContainsKey(key)) return false;
-                continue;
-            }
+            errorList.Add($"requirement '{requirement}' could not be parsed");
+        }
 
-            // Handle key (exists)
-            if (!labels.ContainsKey(requirement)) return false;
+        if (errorList.Count > 0) return false;
+
+        if (matchLabels.Count > 0) selector.MatchLabels = matchLabels;
+        if (matchExpressions.Count > 0) selector.MatchExpressions = matchExpressions;
+        return true;
+    }
+
+    /// <summary>
+    ///     Evaluates a <see cref="V1LabelSelector" /> against a label dictionary using the standard Kubernetes
+    ///     semantics (MatchLabels are ANDed; MatchExpressions are ANDed).
+    /// </summary>
+    internal static bool MatchesLabels(V1LabelSelector selector, IDictionary<string, string> labels)
+    {
+        if (selector.MatchLabels != null)
+            foreach (var kv in selector.MatchLabels)
+                if (!labels.TryGetValue(kv.Key, out var labelValue) || labelValue != kv.Value)
+                    return false;
+
+        if (selector.MatchExpressions == null) return true;
+
+        foreach (var expression in selector.MatchExpressions)
+        {
+            var hasLabel = labels.TryGetValue(expression.Key, out var labelValue);
+            switch (expression.OperatorProperty)
+            {
+                case "In":
+                    if (!hasLabel || expression.Values == null ||
+                        !expression.Values.Contains(labelValue!)) return false;
+                    break;
+                case "NotIn":
+                    if (hasLabel && expression.Values != null &&
+                        expression.Values.Contains(labelValue!)) return false;
+                    break;
+                case "Exists":
+                    if (!hasLabel) return false;
+                    break;
+                case "DoesNotExist":
+                    if (hasLabel) return false;
+                    break;
+                default:
+                    return false;
+            }
         }
 
         return true;
+    }
+
+    private static void CollectLabelSelectorErrors(string annotation, string value, List<string> destination)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        if (TryParseLabelSelector(value, out _, out var parseErrors)) return;
+        foreach (var error in parseErrors)
+            destination.Add($"{annotation} '{value}': {error}");
     }
 
     private static List<string> SplitRequirements(string selector)
@@ -197,47 +289,175 @@ public static class MirroringPropertiesExtensions
         var depth = 0;
         var start = 0;
         for (var i = 0; i < selector.Length; i++)
-        {
             switch (selector[i])
             {
-                case '(': depth++; break;
-                case ')': depth--; break;
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    break;
                 case ',' when depth == 0:
                     var part = selector[start..i].Trim();
                     if (part.Length > 0) results.Add(part);
                     start = i + 1;
                     break;
             }
-        }
+
         var last = selector[start..].Trim();
         if (last.Length > 0) results.Add(last);
         return results;
     }
 
-    private static bool TryParseSetBased(string requirement, IDictionary<string, string> labels, out bool result)
+    private static bool TryParseSetBased(string requirement, out V1LabelSelectorRequirement? result,
+        out string? error)
     {
-        result = false;
+        result = null;
+        error = null;
 
-        // Match "key in (v1,v2)" or "key notin (v1,v2)"
-        var match = Regex.Match(requirement, @"^([a-zA-Z0-9_./-]+)\s+(in|notin)\s+\(([^)]*)\)$");
+        var match = SetBasedRequirementRegex.Match(requirement);
         if (!match.Success) return false;
 
-        var key = match.Groups[1].Value;
-        var op = match.Groups[2].Value;
-        var values = match.Groups[3].Value
+        var key = match.Groups["key"].Value;
+        var op = match.Groups["op"].Value;
+        var values = match.Groups["values"].Value
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(v => v.Trim())
-            .ToHashSet();
+            .ToList();
 
-        labels.TryGetValue(key, out var labelValue);
-
-        result = op switch
+        if (!IsValidLabelKey(key))
         {
-            "in" => labelValue != null && values.Contains(labelValue),
-            "notin" => labelValue == null || !values.Contains(labelValue),
-            _ => false
-        };
+            error = $"invalid label key '{key}' in set-based requirement";
+            return true;
+        }
 
+        if (values.Count == 0)
+        {
+            error = $"set-based requirement for key '{key}' has no values";
+            return true;
+        }
+
+        foreach (var value in values)
+            if (!IsValidLabelValue(value))
+            {
+                error = $"invalid label value '{value}' for key '{key}'";
+                return true;
+            }
+
+        result = new V1LabelSelectorRequirement
+        {
+            Key = key,
+            OperatorProperty = op == "in" ? "In" : "NotIn",
+            Values = values
+        };
         return true;
+    }
+
+    private static bool TryParseInequality(string requirement, List<string> errors,
+        out V1LabelSelectorRequirement? result)
+    {
+        result = null;
+        if (!requirement.Contains("!=")) return false;
+
+        var parts = requirement.Split("!=", 2);
+        var key = parts[0].Trim();
+        var value = parts[1].Trim();
+
+        if (!IsValidLabelKey(key))
+        {
+            errors.Add($"invalid label key '{key}' in inequality requirement");
+            return true;
+        }
+
+        if (!IsValidLabelValue(value))
+        {
+            errors.Add($"invalid label value '{value}' for key '{key}'");
+            return true;
+        }
+
+        result = new V1LabelSelectorRequirement
+        {
+            Key = key,
+            OperatorProperty = "NotIn",
+            Values = new List<string> { value }
+        };
+        return true;
+    }
+
+    private static bool TryParseEquality(string requirement, List<string> errors,
+        Dictionary<string, string> matchLabels)
+    {
+        var doubleEq = requirement.IndexOf("==", StringComparison.Ordinal);
+        var singleEq = requirement.IndexOf('=');
+        if (doubleEq < 0 && singleEq < 0) return false;
+
+        var eqIndex = doubleEq >= 0 ? doubleEq : singleEq;
+        var opLength = doubleEq >= 0 ? 2 : 1;
+        var key = requirement[..eqIndex].Trim();
+        var value = requirement[(eqIndex + opLength)..].Trim();
+
+        if (!IsValidLabelKey(key))
+        {
+            errors.Add($"invalid label key '{key}' in equality requirement");
+            return true;
+        }
+
+        if (!IsValidLabelValue(value))
+        {
+            errors.Add($"invalid label value '{value}' for key '{key}'");
+            return true;
+        }
+
+        matchLabels[key] = value;
+        return true;
+    }
+
+    private static bool TryParseExistence(string requirement, List<string> errors,
+        out V1LabelSelectorRequirement? result)
+    {
+        result = null;
+        var negated = requirement.StartsWith('!');
+        var key = negated ? requirement[1..].Trim() : requirement;
+
+        if (!IsValidLabelKey(key))
+        {
+            errors.Add($"invalid label key '{key}' in existence requirement");
+            return true;
+        }
+
+        result = new V1LabelSelectorRequirement
+        {
+            Key = key,
+            OperatorProperty = negated ? "DoesNotExist" : "Exists"
+        };
+        return true;
+    }
+
+    private static bool IsValidLabelKey(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return false;
+
+        var slashIndex = key.IndexOf('/');
+        string name;
+        if (slashIndex >= 0)
+        {
+            var prefix = key[..slashIndex];
+            if (prefix.Length == 0 || prefix.Length > 253) return false;
+            if (!LabelPrefixRegex.IsMatch(prefix)) return false;
+            name = key[(slashIndex + 1)..];
+        }
+        else
+        {
+            name = key;
+        }
+
+        if (name.Length == 0 || name.Length > 63) return false;
+        return LabelNameRegex.IsMatch(name);
+    }
+
+    private static bool IsValidLabelValue(string value)
+    {
+        if (value.Length > 63) return false;
+        return LabelValueRegex.IsMatch(value);
     }
 }

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/MirroringPropertiesExtensions.cs
@@ -137,6 +137,9 @@ public static class MirroringPropertiesExtensions
         var labels = ns.Metadata?.Labels ?? new Dictionary<string, string>();
         var requirements = SplitRequirements(selector);
 
+        // Fail closed: a non-empty selector that produces no valid requirements is invalid
+        if (requirements.Count == 0) return false;
+
         foreach (var raw in requirements)
         {
             var requirement = raw.Trim();
@@ -154,6 +157,7 @@ public static class MirroringPropertiesExtensions
             {
                 var parts = requirement.Split("!=", 2);
                 var key = parts[0].Trim();
+                if (string.IsNullOrEmpty(key)) return false;
                 var value = parts[1].Trim();
                 if (labels.TryGetValue(key, out var labelValue) && labelValue == value) return false;
                 continue;
@@ -165,6 +169,7 @@ public static class MirroringPropertiesExtensions
             if (eqIndex > 0)
             {
                 var key = requirement[..eqIndex].TrimEnd('=').Trim();
+                if (string.IsNullOrEmpty(key)) return false;
                 var value = requirement[(eqIndex + (requirement[eqIndex..].StartsWith("==") ? 2 : 1))..].Trim();
                 if (!labels.TryGetValue(key, out var labelValue) || labelValue != value) return false;
                 continue;
@@ -174,6 +179,7 @@ public static class MirroringPropertiesExtensions
             if (requirement.StartsWith('!'))
             {
                 var key = requirement[1..].Trim();
+                if (string.IsNullOrEmpty(key)) return false;
                 if (labels.ContainsKey(key)) return false;
                 continue;
             }

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -144,6 +144,27 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                         await OnResourceDelete(reflectionNsName);
                     }
                 }
+
+                //Rebalance any direct reflections targeting this namespace against current labels
+                foreach (var (sourceNsName, reflectionList) in _directReflectionCache)
+                {
+                    if (!_propertiesCache.TryGetValue(sourceNsName, out var sourceProperties)) continue;
+
+                    var staleReflections = reflectionList
+                        .Where(r => r.Namespace == ns.Name())
+                        .ToList();
+                    if (staleReflections.Count == 0) continue;
+
+                    if (CanBeReflectedToNamespaceCached(sourceProperties, ns.Name())) continue;
+
+                    foreach (var reflectionNsName in staleReflections)
+                    {
+                        Logger.LogInformation(
+                            "Source {sourceNsName} no longer permits the direct reflection to {reflectionNsName}.",
+                            sourceNsName, reflectionNsName);
+                        reflectionList.Remove(reflectionNsName);
+                    }
+                }
             }
                 break;
             case V1Namespace ns when notification.EventType == WatchEventType.Deleted:
@@ -160,6 +181,10 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                     var reflectionNsName = sourceNsName with { Namespace = ns.Name() };
                     autoReflections.Remove(reflectionNsName);
                 }
+
+                //Remove any direct reflections targeting this namespace
+                foreach (var reflectionList in _directReflectionCache.Values)
+                    reflectionList.RemoveWhere(r => r.Namespace == ns.Name());
             }
                 break;
         }

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -20,6 +20,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
     private readonly ConcurrentDictionary<NamespacedName, bool> _autoSources = new();
     private readonly ConcurrentDictionary<NamespacedName, HashSet<NamespacedName>> _directReflectionCache = new();
 
+    private readonly ConcurrentDictionary<string, V1Namespace> _namespaceCache = new();
     private readonly ConcurrentDictionary<NamespacedName, bool> _notFoundCache = new();
     private readonly ConcurrentDictionary<NamespacedName, MirroringProperties> _propertiesCache = new();
     protected readonly IKubernetes Kubernetes = kubernetes;
@@ -38,6 +39,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
         Logger.LogDebug("Cleared sources for {Type} resources", typeof(TResource).Name);
 
         _autoSources.Clear();
+        _namespaceCache.Clear();
         _notFoundCache.Clear();
         _propertiesCache.Clear();
         _autoReflectionCache.Clear();
@@ -108,13 +110,16 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 Logger.LogTrace("Handling {eventType} {resourceType} {resourceRef}", notification.EventType, ns.Kind,
                     ns.ObjectReference().NamespacedName());
 
+                //Cache the namespace for label selector lookups
+                _namespaceCache.AddOrUpdate(ns.Name(), ns, (_, _) => ns);
+
                 //Update all auto-sources
                 foreach (var sourceNsName in _autoSources.Keys)
                 {
                     var properties = _propertiesCache[sourceNsName];
 
                     //If it can't be reflected to this namespace, skip
-                    if (!properties.CanBeAutoReflectedToNamespace(ns.Name())) continue;
+                    if (!properties.CanBeAutoReflectedToNamespace(ns)) continue;
 
 
                     //Get the list of auto-reflections
@@ -155,7 +160,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 if (_directReflectionCache.TryGetValue(objNsName, out var reflectionList))
                 {
                     var reflections = reflectionList
-                        .Where(s => !objProperties.CanBeReflectedToNamespace(s.Namespace))
+                        .Where(s => !CanBeReflectedToNamespaceCached(objProperties, s.Namespace))
                         .ToHashSet();
 
                     foreach (var reflectionNsName in reflections)
@@ -172,7 +177,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 if (_autoReflectionCache.TryGetValue(objNsName, out reflectionList))
                 {
                     var reflections = reflectionList
-                        .Where(s => !objProperties.CanBeReflectedToNamespace(s.Namespace))
+                        .Where(s => !CanBeReflectedToNamespaceCached(objProperties, s.Namespace))
                         .ToHashSet();
                     foreach (var reflectionNsName in reflections)
                     {
@@ -263,7 +268,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 _directReflectionCache.TryAdd(sourceNsName, []);
                 _directReflectionCache[sourceNsName].Add(objNsName);
 
-                if (!sourceProperties.CanBeReflectedToNamespace(objNsName.Namespace))
+                if (!CanBeReflectedToNamespaceCached(sourceProperties, objNsName.Namespace))
                 {
                     Logger.LogWarning("Could not update {reflectionNsName} - Source {sourceNsName} does not permit it.",
                         objNsName, sourceNsName);
@@ -326,7 +331,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
 
                 _propertiesCache.AddOrUpdate(sourceNsName, sourceProperties,
                     (_, _) => sourceProperties);
-                if (!sourceProperties.CanBeAutoReflectedToNamespace(objNsName.Namespace))
+                if (!CanBeAutoReflectedToNamespaceCached(sourceProperties, objNsName.Namespace))
                 {
                     Logger.LogInformation(
                         "Source {sourceNsName} no longer permits the auto reflection to {reflectionNsName}. Deleting {reflectionNsName}.",
@@ -354,6 +359,10 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
         var namespaces = (await Kubernetes.CoreV1
             .ListNamespaceAsync(cancellationToken: cancellationToken)).Items;
 
+        //Cache namespaces for label selector lookups
+        foreach (var ns in namespaces)
+            _namespaceCache.AddOrUpdate(ns.Name(), ns, (_, _) => ns);
+
         foreach (var match in matches)
         {
             var matchProperties = match.GetMirroringProperties();
@@ -361,9 +370,12 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 _ => matchProperties, (_, _) => matchProperties);
         }
 
+        var namespaceLookup = namespaces.ToDictionary(n => n.Name());
+
         var toDelete = matches
             .Where(s => s.Namespace() != sourceNsName.Namespace)
-            .Where(m => !sourceProperties.CanBeAutoReflectedToNamespace(m.Namespace()))
+            .Where(m => !namespaceLookup.TryGetValue(m.Namespace(), out var ns) ||
+                        !sourceProperties.CanBeAutoReflectedToNamespace(ns))
             .Where(m => m.GetMirroringProperties().Reflects == sourceNsName)
             .Select(s => s.NamespacedName())
             .ToList();
@@ -377,7 +389,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
             .Where(s => s.Name() != sourceNsName.Namespace)
             .Where(s =>
                 matches.All(m => m.Namespace() != s.Name()) &&
-                sourceProperties.CanBeAutoReflectedToNamespace(s.Name()))
+                sourceProperties.CanBeAutoReflectedToNamespace(s))
             .Select(s => new NamespacedName(s.Name(), sourceNsName.Name)).ToList();
 
         var toUpdate = matches
@@ -557,4 +569,14 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
     protected abstract Task<TResource> OnResourceGet(NamespacedName refId);
 
     protected virtual Task<bool> OnResourceIgnoreCheck(TResource item) => Task.FromResult(false);
+
+    private bool CanBeReflectedToNamespaceCached(MirroringProperties properties, string ns) =>
+        _namespaceCache.TryGetValue(ns, out var nsObj)
+            ? properties.CanBeReflectedToNamespace(nsObj)
+            : properties.CanBeReflectedToNamespace(ns);
+
+    private bool CanBeAutoReflectedToNamespaceCached(MirroringProperties properties, string ns) =>
+        _namespaceCache.TryGetValue(ns, out var nsObj)
+            ? properties.CanBeAutoReflectedToNamespace(nsObj)
+            : properties.CanBeAutoReflectedToNamespace(ns);
 }

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -105,7 +105,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 }
 
                 break;
-            case V1Namespace ns when notification.EventType == WatchEventType.Added:
+            case V1Namespace ns when notification.EventType is WatchEventType.Added or WatchEventType.Modified:
             {
                 Logger.LogTrace("Handling {eventType} {resourceType} {resourceRef}", notification.EventType, ns.Kind,
                     ns.ObjectReference().NamespacedName());
@@ -117,25 +117,45 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 foreach (var sourceNsName in _autoSources.Keys)
                 {
                     var properties = _propertiesCache[sourceNsName];
-
-                    //If it can't be reflected to this namespace, skip
-                    if (!properties.CanBeAutoReflectedToNamespace(ns)) continue;
-
-
-                    //Get the list of auto-reflections
                     var autoReflections = _autoReflectionCache.GetOrAdd(sourceNsName, []);
-
                     var reflectionNsName = sourceNsName with { Namespace = ns.Name() };
 
-                    //Reflect the auto-source to the new namespace
-                    await ResourceReflect(
-                        sourceNsName,
-                        reflectionNsName,
-                        null,
-                        null,
-                        true);
+                    if (properties.CanBeAutoReflectedToNamespace(ns))
+                    {
+                        //Create or update the auto-reflection in this namespace
+                        await ResourceReflect(
+                            sourceNsName,
+                            reflectionNsName,
+                            null,
+                            null,
+                            true);
 
-                    autoReflections.Add(reflectionNsName);
+                        autoReflections.Add(reflectionNsName);
+                    }
+                    else if (autoReflections.Remove(reflectionNsName))
+                    {
+                        //Namespace no longer matches — remove the auto-reflection
+                        Logger.LogDebug(
+                            "Deleting {reflectionNsName} - namespace {ns} no longer matches selector for source {sourceNsName}",
+                            reflectionNsName, ns.Name(), sourceNsName);
+                        await OnResourceDelete(reflectionNsName);
+                    }
+                }
+            }
+                break;
+            case V1Namespace ns when notification.EventType == WatchEventType.Deleted:
+            {
+                Logger.LogTrace("Handling {eventType} {resourceType} {resourceRef}", notification.EventType, ns.Kind,
+                    ns.ObjectReference().NamespacedName());
+
+                _namespaceCache.TryRemove(ns.Name(), out _);
+
+                //Remove any auto-reflections targeting this namespace
+                foreach (var sourceNsName in _autoSources.Keys)
+                {
+                    var autoReflections = _autoReflectionCache.GetOrAdd(sourceNsName, []);
+                    var reflectionNsName = sourceNsName with { Namespace = ns.Name() };
+                    autoReflections.Remove(reflectionNsName);
                 }
             }
                 break;

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -23,6 +23,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
     private readonly ConcurrentDictionary<string, V1Namespace> _namespaceCache = new();
     private readonly ConcurrentDictionary<NamespacedName, bool> _notFoundCache = new();
     private readonly ConcurrentDictionary<NamespacedName, MirroringProperties> _propertiesCache = new();
+    private readonly ConcurrentDictionary<NamespacedName, string> _lastWarnedSelectorErrors = new();
     protected readonly IKubernetes Kubernetes = kubernetes;
     protected readonly ILogger Logger = logger;
 
@@ -43,6 +44,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
         _notFoundCache.Clear();
         _propertiesCache.Clear();
         _autoReflectionCache.Clear();
+        _lastWarnedSelectorErrors.Clear();
 
         return Task.CompletedTask;
     }
@@ -74,6 +76,7 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                     case WatchEventType.Deleted:
                     {
                         _propertiesCache.Remove(objNsName, out _);
+                        _lastWarnedSelectorErrors.TryRemove(objNsName, out _);
                         var properties = obj.GetMirroringProperties();
 
                         if (!properties.IsReflection)
@@ -170,6 +173,8 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
 
         _propertiesCache.AddOrUpdate(objNsName, objProperties,
             (_, _) => objProperties);
+
+        WarnOnInvalidLabelSelectors(objNsName, objProperties);
 
         switch (objProperties)
         {
@@ -589,6 +594,23 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
     protected abstract Task<TResource> OnResourceGet(NamespacedName refId);
 
     protected virtual Task<bool> OnResourceIgnoreCheck(TResource item) => Task.FromResult(false);
+
+    private void WarnOnInvalidLabelSelectors(NamespacedName sourceNsName, MirroringProperties properties)
+    {
+        var errors = properties.GetLabelSelectorErrors();
+        if (errors.Count == 0)
+        {
+            _lastWarnedSelectorErrors.TryRemove(sourceNsName, out _);
+            return;
+        }
+
+        var signature = string.Join("|", errors);
+        if (_lastWarnedSelectorErrors.TryGetValue(sourceNsName, out var previous) && previous == signature) return;
+
+        _lastWarnedSelectorErrors[sourceNsName] = signature;
+        foreach (var error in errors)
+            Logger.LogWarning("Invalid label selector on source {sourceNsName}: {error}", sourceNsName, error);
+    }
 
     private bool CanBeReflectedToNamespaceCached(MirroringProperties properties, string ns)
     {

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -16,6 +16,8 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
     IWatcherEventHandler, IWatcherClosedHandler
     where TResource : class, IKubernetesObject<V1ObjectMeta>
 {
+    private static readonly IDictionary<string, string> EmptyLabels = new Dictionary<string, string>();
+
     private readonly ConcurrentDictionary<NamespacedName, HashSet<NamespacedName>> _autoReflectionCache = new();
     private readonly ConcurrentDictionary<NamespacedName, bool> _autoSources = new();
     private readonly ConcurrentDictionary<NamespacedName, HashSet<NamespacedName>> _directReflectionCache = new();
@@ -112,6 +114,13 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
             {
                 Logger.LogTrace("Handling {eventType} {resourceType} {resourceRef}", notification.EventType, ns.Kind,
                     ns.ObjectReference().NamespacedName());
+
+                // Skip reconciliation when only non-label fields changed (status, annotations, resourceVersion).
+                // Reflection eligibility is purely a function of namespace name and labels.
+                if (notification.EventType == WatchEventType.Modified &&
+                    _namespaceCache.TryGetValue(ns.Name(), out var cachedNs) &&
+                    NamespaceLabelsEqual(cachedNs, ns))
+                    break;
 
                 //Cache the namespace for label selector lookups
                 _namespaceCache.AddOrUpdate(ns.Name(), ns, (_, _) => ns);
@@ -636,6 +645,9 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
         foreach (var error in errors)
             Logger.LogWarning("Invalid label selector on source {sourceNsName}: {error}", sourceNsName, error);
     }
+
+    internal static bool NamespaceLabelsEqual(V1Namespace a, V1Namespace b) =>
+        (a.Metadata?.Labels ?? EmptyLabels).SequenceEqual(b.Metadata?.Labels ?? EmptyLabels);
 
     private bool CanBeReflectedToNamespaceCached(MirroringProperties properties, string ns)
     {

--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -590,13 +590,38 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
 
     protected virtual Task<bool> OnResourceIgnoreCheck(TResource item) => Task.FromResult(false);
 
-    private bool CanBeReflectedToNamespaceCached(MirroringProperties properties, string ns) =>
-        _namespaceCache.TryGetValue(ns, out var nsObj)
-            ? properties.CanBeReflectedToNamespace(nsObj)
-            : properties.CanBeReflectedToNamespace(ns);
+    private bool CanBeReflectedToNamespaceCached(MirroringProperties properties, string ns)
+    {
+        if (_namespaceCache.TryGetValue(ns, out var nsObj))
+            return properties.CanBeReflectedToNamespace(nsObj);
 
-    private bool CanBeAutoReflectedToNamespaceCached(MirroringProperties properties, string ns) =>
-        _namespaceCache.TryGetValue(ns, out var nsObj)
-            ? properties.CanBeAutoReflectedToNamespace(nsObj)
-            : properties.CanBeAutoReflectedToNamespace(ns);
+        // Fail closed: a label selector cannot be evaluated without the namespace object.
+        // Falling back to the name-only overload would match empty-pattern sources and allow all namespaces.
+        if (!string.IsNullOrEmpty(properties.AllowedNamespacesSelector))
+        {
+            Logger.LogDebug(
+                "Namespace {ns} not in cache; denying reflection because a label selector is configured.", ns);
+            return false;
+        }
+
+        return properties.CanBeReflectedToNamespace(ns);
+    }
+
+    private bool CanBeAutoReflectedToNamespaceCached(MirroringProperties properties, string ns)
+    {
+        if (_namespaceCache.TryGetValue(ns, out var nsObj))
+            return properties.CanBeAutoReflectedToNamespace(nsObj);
+
+        // Fail closed: a label selector cannot be evaluated without the namespace object.
+        // Falling back to the name-only overload would match empty-pattern sources and allow all namespaces.
+        if (!string.IsNullOrEmpty(properties.AllowedNamespacesSelector) ||
+            !string.IsNullOrEmpty(properties.AutoNamespacesSelector))
+        {
+            Logger.LogDebug(
+                "Namespace {ns} not in cache; denying auto-reflection because a label selector is configured.", ns);
+            return false;
+        }
+
+        return properties.CanBeAutoReflectedToNamespace(ns);
+    }
 }

--- a/tests/ES.Kubernetes.Reflector.Tests/Additions/ReflectorAnnotationsBuilder.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/Additions/ReflectorAnnotationsBuilder.cs
@@ -18,6 +18,12 @@ public sealed class ReflectorAnnotationsBuilder
         return this;
     }
 
+    public ReflectorAnnotationsBuilder WithAllowedNamespacesSelector(string selector)
+    {
+        _annotations[Annotations.Reflection.AllowedNamespacesSelector] = selector;
+        return this;
+    }
+
     public ReflectorAnnotationsBuilder WithAutoEnabled(bool enabled)
     {
         _annotations[Annotations.Reflection.AutoEnabled] = enabled.ToString().ToLower();
@@ -27,6 +33,12 @@ public sealed class ReflectorAnnotationsBuilder
     public ReflectorAnnotationsBuilder WithAutoNamespaces(bool enabled, params string[] namespaces)
     {
         _annotations[Annotations.Reflection.AutoNamespaces] = enabled ? string.Join(",", namespaces) : string.Empty;
+        return this;
+    }
+
+    public ReflectorAnnotationsBuilder WithAutoNamespacesSelector(string selector)
+    {
+        _annotations[Annotations.Reflection.AutoNamespacesSelector] = selector;
         return this;
     }
 

--- a/tests/ES.Kubernetes.Reflector.Tests/Integration/Base/BaseIntegrationTest.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/Integration/Base/BaseIntegrationTest.cs
@@ -24,10 +24,22 @@ public class BaseIntegrationTest(ReflectorIntegrationFixture integrationFixture)
             .AddTimeout(TimeSpan.FromSeconds(30))
             .Build();
 
+    protected static readonly ResiliencePipeline<bool> ResourceAbsentResiliencePipeline =
+        new ResiliencePipelineBuilder<bool>()
+            .AddRetry(new RetryStrategyOptions<bool>
+            {
+                ShouldHandle = new PredicateBuilder<bool>().HandleResult(true),
+                MaxRetryAttempts = 10,
+                Delay = TimeSpan.FromSeconds(1)
+            })
+            .AddTimeout(TimeSpan.FromSeconds(30))
+            .Build();
+
     protected async Task<IKubernetes> GetKubernetesClient() =>
         await integrationFixture.Kubernetes.GetKubernetesClient();
 
-    protected async Task<V1Namespace?> CreateNamespaceAsync(string name)
+    protected async Task<V1Namespace?> CreateNamespaceAsync(string name,
+        IDictionary<string, string>? labels = null)
     {
         var client = await GetKubernetesClient();
         var ns = new V1Namespace
@@ -36,7 +48,8 @@ public class BaseIntegrationTest(ReflectorIntegrationFixture integrationFixture)
             Kind = V1Namespace.KubeKind,
             Metadata = new V1ObjectMeta
             {
-                Name = name
+                Name = name,
+                Labels = labels
             }
         };
 

--- a/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
@@ -82,6 +82,69 @@ public class MirroringIntegrationTests(
 
 
     [Fact]
+    public async Task AutoReflect_To_NamespacesMatchingLabelSelector()
+    {
+        var client = await GetKubernetesClient();
+
+        var matchingNamespace = $"match-{Guid.CreateVersion7()}";
+        var nonMatchingNamespace = $"nomatch-{Guid.CreateVersion7()}";
+
+        await CreateNamespaceAsync(matchingNamespace,
+            new Dictionary<string, string> { ["reflector-test-env"] = "prod" });
+        await CreateNamespaceAsync(nonMatchingNamespace,
+            new Dictionary<string, string> { ["reflector-test-env"] = "dev" });
+
+        var sourceResource = await CreateResource(client,
+            annotations: new ReflectorAnnotationsBuilder()
+                .WithReflectionAllowed(true)
+                .WithAllowedNamespacesSelector("reflector-test-env=prod")
+                .WithAutoEnabled(true).Build());
+
+        await DelayForReflection();
+
+        Assert.True(await WaitForResource(client, sourceResource.Name(), matchingNamespace,
+            TestContext.Current.CancellationToken));
+
+        Assert.False(await ResourceExists(client, sourceResource.Name(), nonMatchingNamespace,
+            TestContext.Current.CancellationToken));
+    }
+
+
+    [Fact]
+    public async Task AutoReflect_UpdatesReflections_WhenNamespaceLabelsChange()
+    {
+        var client = await GetKubernetesClient();
+
+        var targetNamespace = $"labelshift-{Guid.CreateVersion7()}";
+        await CreateNamespaceAsync(targetNamespace,
+            new Dictionary<string, string> { ["reflector-test-env"] = "dev" });
+
+        var sourceResource = await CreateResource(client,
+            annotations: new ReflectorAnnotationsBuilder()
+                .WithReflectionAllowed(true)
+                .WithAllowedNamespacesSelector("reflector-test-env=prod")
+                .WithAutoEnabled(true).Build());
+
+        await DelayForReflection();
+
+        Assert.False(await ResourceExists(client, sourceResource.Name(), targetNamespace,
+            TestContext.Current.CancellationToken));
+
+        await PatchNamespaceLabelsAsync(client, targetNamespace,
+            new Dictionary<string, string?> { ["reflector-test-env"] = "prod" });
+
+        Assert.True(await WaitForResource(client, sourceResource.Name(), targetNamespace,
+            TestContext.Current.CancellationToken));
+
+        await PatchNamespaceLabelsAsync(client, targetNamespace,
+            new Dictionary<string, string?> { ["reflector-test-env"] = "dev" });
+
+        Assert.True(await WaitForResourceAbsent(client, sourceResource.Name(), targetNamespace,
+            TestContext.Current.CancellationToken));
+    }
+
+
+    [Fact]
     public async Task AutoReflect_Remove_ReflectionsWhenResourceDeleted()
     {
         var client = await GetKubernetesClient();
@@ -165,6 +228,24 @@ public class MirroringIntegrationTests(
                 name, namespaceName, cancellationToken: token);
             return resource is not null;
         }, cancellationToken);
+    }
+
+
+    private async Task<bool> WaitForResourceAbsent(IKubernetes client, string name, string namespaceName,
+        CancellationToken cancellationToken = default)
+    {
+        return await ResourceAbsentResiliencePipeline.ExecuteAsync(async token =>
+            await ResourceExists(client, name, namespaceName, token), cancellationToken) == false;
+    }
+
+
+    private static async Task PatchNamespaceLabelsAsync(IKubernetes client, string namespaceName,
+        IDictionary<string, string?> labels)
+    {
+        var patch = new V1Patch(
+            new { metadata = new { labels } },
+            V1Patch.PatchType.MergePatch);
+        await client.CoreV1.PatchNamespaceAsync(patch, namespaceName);
     }
 
 

--- a/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
@@ -145,6 +145,70 @@ public class MirroringIntegrationTests(
 
 
     [Fact]
+    public async Task DirectReflect_StopsUpdating_WhenNamespaceLabelsNoLongerMatchSelector()
+    {
+        var client = await GetKubernetesClient();
+
+        var sourceNamespace = $"src-{Guid.CreateVersion7()}";
+        var targetNamespace = $"labelshift-direct-{Guid.CreateVersion7()}";
+        var dataKey = "payload";
+        var initialValue = Guid.NewGuid().ToString();
+        var updatedValue = Guid.NewGuid().ToString();
+
+        await CreateNamespaceAsync(targetNamespace,
+            new Dictionary<string, string> { ["reflector-test-env"] = "prod" });
+
+        var sourceResource = await CreateResource(client,
+            namespaceName: sourceNamespace,
+            annotations: new ReflectorAnnotationsBuilder()
+                .WithReflectionAllowed(true)
+                .WithAllowedNamespacesSelector("reflector-test-env=prod").Build(),
+            data: new Dictionary<string, string> { [dataKey] = initialValue });
+
+        var directReflection = new V1Secret
+        {
+            ApiVersion = V1Secret.KubeApiVersion,
+            Kind = V1Secret.KubeKind,
+            Metadata = new V1ObjectMeta
+            {
+                Name = sourceResource.Name(),
+                NamespaceProperty = targetNamespace,
+                Annotations = new Dictionary<string, string>
+                {
+                    [$"{ES.Kubernetes.Reflector.Mirroring.Core.Annotations.Prefix}/reflects"]
+                        = $"{sourceNamespace}/{sourceResource.Name()}"
+                }
+            },
+            StringData = new Dictionary<string, string> { [dataKey] = "placeholder" },
+            Type = "Opaque"
+        };
+        await client.CoreV1.CreateNamespacedSecretAsync(directReflection, targetNamespace,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(await WaitForSecretDataValue(client, sourceResource.Name(), targetNamespace,
+            dataKey, initialValue, TestContext.Current.CancellationToken));
+
+        await PatchNamespaceLabelsAsync(client, targetNamespace,
+            new Dictionary<string, string?> { ["reflector-test-env"] = "staging" });
+
+        await DelayForReflection();
+
+        var patch = new V1Patch(
+            new { stringData = new Dictionary<string, string> { [dataKey] = updatedValue } },
+            V1Patch.PatchType.MergePatch);
+        await client.CoreV1.PatchNamespacedSecretAsync(patch, sourceResource.Name(), sourceNamespace,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var mirror = await client.CoreV1.ReadNamespacedSecretAsync(sourceResource.Name(), targetNamespace,
+            cancellationToken: TestContext.Current.CancellationToken);
+        var actual = System.Text.Encoding.UTF8.GetString(mirror.Data[dataKey]);
+        Assert.Equal(initialValue, actual);
+    }
+
+
+    [Fact]
     public async Task AutoReflect_Remove_ReflectionsWhenResourceDeleted()
     {
         var client = await GetKubernetesClient();
@@ -236,6 +300,18 @@ public class MirroringIntegrationTests(
     {
         return await ResourceAbsentResiliencePipeline.ExecuteAsync(async token =>
             await ResourceExists(client, name, namespaceName, token), cancellationToken) == false;
+    }
+
+
+    private async Task<bool> WaitForSecretDataValue(IKubernetes client, string name, string namespaceName,
+        string dataKey, string expected, CancellationToken cancellationToken = default)
+    {
+        return await ResourceExistsResiliencePipeline.ExecuteAsync(async token =>
+        {
+            var secret = await client.CoreV1.ReadNamespacedSecretAsync(name, namespaceName, cancellationToken: token);
+            if (secret.Data is null || !secret.Data.TryGetValue(dataKey, out var bytes)) return false;
+            return System.Text.Encoding.UTF8.GetString(bytes) == expected;
+        }, cancellationToken);
     }
 
 

--- a/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
@@ -234,4 +234,67 @@ public class LabelSelectorMatchTests
         };
         Assert.True(props.CanBeAutoReflectedToNamespace(ns));
     }
+
+    [Theory]
+    [InlineData("-env=prod")]
+    [InlineData("env-=prod")]
+    [InlineData(".env=prod")]
+    [InlineData("env name=prod")]
+    public void InvalidSelector_InvalidLabelKey_FailsClosed(string selector)
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "prod" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch(selector, ns));
+    }
+
+    [Fact]
+    public void InvalidSelector_LabelKeyTooLong_FailsClosed()
+    {
+        var longName = new string('a', 64);
+        var ns = CreateNamespace("test");
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch($"{longName}=value", ns));
+    }
+
+    [Fact]
+    public void ValidSelector_PrefixedLabelKey_Matches()
+    {
+        var ns = CreateNamespace("test",
+            new Dictionary<string, string> { { "app.kubernetes.io/name", "reflector" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch(
+            "app.kubernetes.io/name=reflector", ns));
+    }
+
+    [Fact]
+    public void GetLabelSelectorErrors_ValidSelectors_ReturnsEmpty()
+    {
+        var props = new MirroringProperties
+        {
+            AllowedNamespacesSelector = "env=prod",
+            AutoNamespacesSelector = "tier in (frontend,backend)"
+        };
+        Assert.Empty(props.GetLabelSelectorErrors());
+    }
+
+    [Fact]
+    public void GetLabelSelectorErrors_InvalidSelector_ReturnsErrors()
+    {
+        var props = new MirroringProperties
+        {
+            AllowedNamespacesSelector = "=prod",
+            AutoNamespacesSelector = "valid=value"
+        };
+        var errors = props.GetLabelSelectorErrors();
+        Assert.NotEmpty(errors);
+        Assert.Contains(errors, e => e.Contains("reflection-allowed-namespaces-selector"));
+    }
+
+    [Fact]
+    public void GetLabelSelectorErrors_EmptySelectors_ReturnsEmpty()
+    {
+        var props = new MirroringProperties
+        {
+            AllowedNamespacesSelector = string.Empty,
+            AutoNamespacesSelector = string.Empty
+        };
+        Assert.Empty(props.GetLabelSelectorErrors());
+    }
 }

--- a/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
@@ -157,6 +157,18 @@ public class LabelSelectorMatchTests
         Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch(selector, ns));
     }
 
+    [Theory]
+    [InlineData("env in (prod")]
+    [InlineData("env in prod)")]
+    [InlineData("env in ()")]
+    [InlineData("()")]
+    [InlineData("=")]
+    public void InvalidSelector_MalformedExpression_FailsClosed(string selector)
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch(selector, ns));
+    }
+
     [Fact]
     public void MirroringProperties_AllowedNamespacesSelector_MatchesByLabel()
     {

--- a/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
@@ -137,6 +137,26 @@ public class LabelSelectorMatchTests
         Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env notin (production,staging)", ns));
     }
 
+    [Theory]
+    [InlineData(",")]
+    [InlineData(",,")]
+    [InlineData(", ,")]
+    public void InvalidSelector_CommasOnly_FailsClosed(string selector)
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch(selector, ns));
+    }
+
+    [Theory]
+    [InlineData("!")]
+    [InlineData("!=value")]
+    [InlineData("=value")]
+    public void InvalidSelector_EmptyKey_FailsClosed(string selector)
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch(selector, ns));
+    }
+
     [Fact]
     public void MirroringProperties_AllowedNamespacesSelector_MatchesByLabel()
     {

--- a/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/LabelSelectorMatchTests.cs
@@ -1,0 +1,205 @@
+using ES.Kubernetes.Reflector.Mirroring.Core;
+using k8s.Models;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class LabelSelectorMatchTests
+{
+    private static V1Namespace CreateNamespace(string name, Dictionary<string, string>? labels = null) =>
+        new()
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name,
+                Labels = labels ?? new Dictionary<string, string>()
+            }
+        };
+
+    [Fact]
+    public void EmptySelector_MatchesAll()
+    {
+        var ns = CreateNamespace("test");
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("", ns));
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("  ", ns));
+    }
+
+    [Fact]
+    public void EqualitySelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env=production", ns));
+    }
+
+    [Fact]
+    public void EqualitySelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "staging" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env=production", ns));
+    }
+
+    [Fact]
+    public void DoubleEqualitySelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env==production", ns));
+    }
+
+    [Fact]
+    public void InequalitySelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "staging" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env!=production", ns));
+    }
+
+    [Fact]
+    public void InequalitySelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env!=production", ns));
+    }
+
+    [Fact]
+    public void InequalitySelector_MissingLabel_Matches()
+    {
+        var ns = CreateNamespace("test");
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env!=production", ns));
+    }
+
+    [Fact]
+    public void ExistsSelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env", ns));
+    }
+
+    [Fact]
+    public void ExistsSelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test");
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env", ns));
+    }
+
+    [Fact]
+    public void NotExistsSelector_Matches()
+    {
+        var ns = CreateNamespace("test");
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("!env", ns));
+    }
+
+    [Fact]
+    public void NotExistsSelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("!env", ns));
+    }
+
+    [Fact]
+    public void MultipleSelectors_AllMustMatch()
+    {
+        var ns = CreateNamespace("test",
+            new Dictionary<string, string> { { "env", "production" }, { "tier", "frontend" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env=production,tier=frontend", ns));
+    }
+
+    [Fact]
+    public void MultipleSelectors_OneFails()
+    {
+        var ns = CreateNamespace("test",
+            new Dictionary<string, string> { { "env", "production" }, { "tier", "backend" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env=production,tier=frontend", ns));
+    }
+
+    [Fact]
+    public void InSelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "staging" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env in (production,staging)", ns));
+    }
+
+    [Fact]
+    public void InSelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "dev" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env in (production,staging)", ns));
+    }
+
+    [Fact]
+    public void NotInSelector_Matches()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "dev" } });
+        Assert.True(MirroringPropertiesExtensions.LabelSelectorMatch("env notin (production,staging)", ns));
+    }
+
+    [Fact]
+    public void NotInSelector_DoesNotMatch()
+    {
+        var ns = CreateNamespace("test", new Dictionary<string, string> { { "env", "production" } });
+        Assert.False(MirroringPropertiesExtensions.LabelSelectorMatch("env notin (production,staging)", ns));
+    }
+
+    [Fact]
+    public void MirroringProperties_AllowedNamespacesSelector_MatchesByLabel()
+    {
+        var ns = CreateNamespace("my-ns", new Dictionary<string, string> { { "env", "production" } });
+        var props = new MirroringProperties
+        {
+            Allowed = true,
+            AllowedNamespacesSelector = "env=production"
+        };
+        Assert.True(props.CanBeReflectedToNamespace(ns));
+    }
+
+    [Fact]
+    public void MirroringProperties_AllowedNamespacesSelector_DoesNotMatchByLabel()
+    {
+        var ns = CreateNamespace("my-ns", new Dictionary<string, string> { { "env", "staging" } });
+        var props = new MirroringProperties
+        {
+            Allowed = true,
+            AllowedNamespaces = "other-ns",
+            AllowedNamespacesSelector = "env=production"
+        };
+        Assert.False(props.CanBeReflectedToNamespace(ns));
+    }
+
+    [Fact]
+    public void MirroringProperties_OrLogic_NameMatchWins()
+    {
+        var ns = CreateNamespace("my-ns", new Dictionary<string, string> { { "env", "staging" } });
+        var props = new MirroringProperties
+        {
+            Allowed = true,
+            AllowedNamespaces = "my-ns",
+            AllowedNamespacesSelector = "env=production"
+        };
+        // Name matches even though label doesn't
+        Assert.True(props.CanBeReflectedToNamespace(ns));
+    }
+
+    [Fact]
+    public void MirroringProperties_OrLogic_LabelMatchWins()
+    {
+        var ns = CreateNamespace("my-ns", new Dictionary<string, string> { { "env", "production" } });
+        var props = new MirroringProperties
+        {
+            Allowed = true,
+            AllowedNamespaces = "other-ns",
+            AllowedNamespacesSelector = "env=production"
+        };
+        // Label matches even though name doesn't
+        Assert.True(props.CanBeReflectedToNamespace(ns));
+    }
+
+    [Fact]
+    public void MirroringProperties_AutoNamespacesSelector()
+    {
+        var ns = CreateNamespace("my-ns", new Dictionary<string, string> { { "env", "production" } });
+        var props = new MirroringProperties
+        {
+            Allowed = true,
+            AutoEnabled = true,
+            AutoNamespacesSelector = "env=production"
+        };
+        Assert.True(props.CanBeAutoReflectedToNamespace(ns));
+    }
+}

--- a/tests/ES.Kubernetes.Reflector.Tests/NamespaceLabelsEqualTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/NamespaceLabelsEqualTests.cs
@@ -1,0 +1,62 @@
+using ES.Kubernetes.Reflector.Mirroring;
+using ES.Kubernetes.Reflector.Mirroring.Core;
+using k8s.Models;
+
+namespace ES.Kubernetes.Reflector.Tests;
+
+public class NamespaceLabelsEqualTests
+{
+    private static V1Namespace Ns(Dictionary<string, string>? labels) =>
+        new()
+        {
+            Metadata = new V1ObjectMeta { Name = "ns", Labels = labels }
+        };
+
+    [Fact]
+    public void NullAndEmpty_AreEqual()
+    {
+        Assert.True(ResourceMirror<V1Secret>.NamespaceLabelsEqual(Ns(null), Ns(new())));
+        Assert.True(ResourceMirror<V1Secret>.NamespaceLabelsEqual(Ns(new()), Ns(null)));
+        Assert.True(ResourceMirror<V1Secret>.NamespaceLabelsEqual(Ns(null), Ns(null)));
+    }
+
+    [Fact]
+    public void SameLabels_AreEqual()
+    {
+        var a = Ns(new() { ["env"] = "prod", ["tier"] = "frontend" });
+        var b = Ns(new() { ["env"] = "prod", ["tier"] = "frontend" });
+        Assert.True(ResourceMirror<V1Secret>.NamespaceLabelsEqual(a, b));
+    }
+
+    [Fact]
+    public void ChangedValue_IsNotEqual()
+    {
+        var a = Ns(new() { ["env"] = "prod" });
+        var b = Ns(new() { ["env"] = "staging" });
+        Assert.False(ResourceMirror<V1Secret>.NamespaceLabelsEqual(a, b));
+    }
+
+    [Fact]
+    public void AddedLabel_IsNotEqual()
+    {
+        var a = Ns(new() { ["env"] = "prod" });
+        var b = Ns(new() { ["env"] = "prod", ["tier"] = "frontend" });
+        Assert.False(ResourceMirror<V1Secret>.NamespaceLabelsEqual(a, b));
+    }
+
+    [Fact]
+    public void RemovedLabel_IsNotEqual()
+    {
+        var a = Ns(new() { ["env"] = "prod", ["tier"] = "frontend" });
+        var b = Ns(new() { ["env"] = "prod" });
+        Assert.False(ResourceMirror<V1Secret>.NamespaceLabelsEqual(a, b));
+    }
+
+    [Fact]
+    public void RenamedKey_IsNotEqual()
+    {
+        var a = Ns(new() { ["env"] = "prod" });
+        var b = Ns(new() { ["environment"] = "prod" });
+        Assert.False(ResourceMirror<V1Secret>.NamespaceLabelsEqual(a, b));
+    }
+}


### PR DESCRIPTION
Add two new annotations that allow selecting target namespaces by
Kubernetes label selectors instead of only name regex patterns:
- reflection-allowed-namespaces-selector
- reflection-auto-namespaces-selector

When both a name-pattern and a label selector annotation are set, a
namespace matches if it satisfies either condition (OR logic). The label
selector supports standard Kubernetes syntax: equality (=, ==, !=),
existence, and set-based (in, notin) expressions.

This is useful when you want to reflect a secret to a subset of non-deterministic namespaces, that can't be represented with a regex. 

For my use case, it makes the manual overhead of managing reflector a lot smaller, as I can automate the label configuration for my namespaces ahead of time, to know that they will be receiving the secrets when the namespace is created with a specified label. 

This is based on the suggestion in: [Discussion #409](https://github.com/emberstack/kubernetes-reflector/discussions/409)
