### PR TITLE
Added deploymentAnnotations

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -5,6 +5,10 @@ kind: Deployment
 metadata:
   name: {{ include "reflector.fullname" . }}
   namespace: {{ include "reflector.namespace" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "reflector.labels" . | nindent 4 }}
 

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -47,6 +47,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# additional annotations to set on the deployment
+deploymentAnnotations: {}
 # additional annotations to set on the pod
 podAnnotations: {}
 # additional labels to set on the pod


### PR DESCRIPTION
Added ability to configure deployment annotations.

Why?
We need to be able to configure sync-waves in Argo, so reflector deployment can be created only after imagePullSecret exists