### PR TITLE
feat(helm): set defaults matching pss-restricted

### DIFF
--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -56,14 +56,18 @@ extraEnv: []
 
 podSecurityContext:
   fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   capabilities:
     drop:
       - ALL
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000
+  runAsGroup: 2000
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
The default security profile nearly matched PSS Restricted.

This PR adds the missing fields to make the default security settings for reflector compatible with the restricted security profile.