### PR TITLE
feat(helm): Add optional support for hostUsers

### DIFF
--- a/src/helm/reflector/templates/deployment.yaml
+++ b/src/helm/reflector/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "reflector.serviceAccountName" . }}
+      hostUsers: {{ .Values.hostUsers }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.priorityClassName }}

--- a/src/helm/reflector/values.yaml
+++ b/src/helm/reflector/values.yaml
@@ -54,6 +54,13 @@ podLabels: {}
 # additional env vars to add to the pod
 extraEnv: []
 
+# When true, pods share the host user namespace (user namespaces are DISABLED).
+# When false, pods use separate user namespaces (user namespaces are ENABLED) for stronger isolation,
+# if supported by the cluster. Set this to false if your cluster supports user namespaces and you want
+# additional isolation; leave as true if user namespaces are not available.
+# See: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+hostUsers: true
+
 podSecurityContext:
   fsGroup: 2000
 


### PR DESCRIPTION
This provides a clear place to set the optional hostUsers isolation for reflector pods.