### PR TITLE
fix: do not record a source's own namespace as an auto-reflection

### DIFF
--- a/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
+++ b/src/ES.Kubernetes.Reflector/Mirroring/Core/ResourceMirror.cs
@@ -140,6 +140,16 @@ public abstract class ResourceMirror<TResource>(ILogger logger, IKubernetes kube
                 {
                     if (!_propertiesCache.TryGetValue(sourceNsName, out var properties)) continue;
 
+                    // Never treat the source's own namespace as an auto-reflection
+                    // target. ResourceReflect already no-ops a self-reflection, but
+                    // without this guard the source's own namespace is still recorded
+                    // in the auto-reflection cache below; a later source update that no
+                    // longer permits that namespace then deletes the cached
+                    // "reflection" — which is the source itself, cascading to the real
+                    // mirrors. AutoReflectionForSource excludes the source namespace
+                    // for the same reason. See #672.
+                    if (sourceNsName.Namespace == ns.Name()) continue;
+
                     var autoReflections = _autoReflectionCache.GetOrAdd(sourceNsName, []);
                     var reflectionNsName = sourceNsName with { Namespace = ns.Name() };
 

--- a/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
+++ b/tests/ES.Kubernetes.Reflector.Tests/Integration/MirroringIntegrationTests.cs
@@ -55,6 +55,71 @@ public class MirroringIntegrationTests(
 
 
     [Fact]
+    public async Task AutoReflect_DoesNotDeleteSource_WhenSourceNamespaceMatchesOwnPattern()
+    {
+        // Regression test for #672. When the source's own namespace matches its
+        // allowed/auto pattern, a namespace event for that namespace records the
+        // source's own namespace in the auto-reflection cache (the reflection
+        // itself is a no-op, but the cache entry is still added). When the source
+        // is later updated to no longer permit that namespace, the cached
+        // "auto-reflection" is deleted — which is the source resource itself,
+        // cascading to the real mirrors.
+        var client = await GetKubernetesClient();
+
+        var sourceNamespace = $"self-src-{Guid.CreateVersion7()}";
+        var targetNamespace = $"self-dst-{Guid.CreateVersion7()}";
+
+        await CreateNamespaceAsync(sourceNamespace);
+        await CreateNamespaceAsync(targetNamespace);
+
+        // The allowed/auto pattern initially matches BOTH namespaces, including
+        // the source's own.
+        var sourceResource = await CreateResource(client,
+            namespaceName: sourceNamespace,
+            annotations: new ReflectorAnnotationsBuilder()
+                .WithReflectionAllowed(true)
+                .WithAllowedNamespaces($"^{sourceNamespace}$", $"^{targetNamespace}$")
+                .WithAutoEnabled(true).Build());
+
+        // Auto-reflection reaches the genuine target namespace.
+        Assert.True(await WaitForResource(client, sourceResource.Name(), targetNamespace,
+            TestContext.Current.CancellationToken));
+
+        // Fire a namespace event for the source's OWN namespace. Pre-fix, this
+        // records the source's own namespace as an auto-reflection target.
+        await PatchNamespaceLabelsAsync(client, sourceNamespace,
+            new Dictionary<string, string?> { ["reflector-test-touch"] = Guid.NewGuid().ToString() });
+        await DelayForReflection();
+
+        // Update the source so its own namespace is no longer permitted (only the
+        // target remains). Pre-fix, this deletes the stale auto-reflection cached
+        // for the source's own namespace — i.e. the source itself.
+        var patch = new V1Patch(
+            new
+            {
+                metadata = new
+                {
+                    annotations = new Dictionary<string, string>
+                    {
+                        [ES.Kubernetes.Reflector.Mirroring.Core.Annotations.Reflection.AllowedNamespaces] =
+                            $"^{targetNamespace}$"
+                    }
+                }
+            },
+            V1Patch.PatchType.MergePatch);
+        await client.CoreV1.PatchNamespacedSecretAsync(patch, sourceResource.Name(), sourceNamespace,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Give the reflector time to (incorrectly) process the deletion.
+        await Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // The source must still exist.
+        Assert.True(await ResourceExists(client, sourceResource.Name(), sourceNamespace,
+            TestContext.Current.CancellationToken));
+    }
+
+
+    [Fact]
     public async Task AutoReflect_To_NewNamespaces()
     {
         var client = await GetKubernetesClient();


### PR DESCRIPTION
Fixes #672: an auto-reflected source is deleted when its own namespace matches
its `reflection-allowed-namespaces`, typically after the allowed list is later
narrowed. The deletion then cascades to the real mirrors.

`AutoReflectionForSource` already excludes the source's own namespace from its
create/update/delete sets. The incremental namespace-event handler does not: for
a namespace event whose namespace equals the source's own, `ResourceReflect`
correctly no-ops the self-reflection, but the handler still records the source's
own namespace in `_autoReflectionCache`. When the source is later updated to no
longer permit that namespace, `HandleUpsert` deletes the cached "auto-reflection"
for it — which resolves to the source resource itself — cascading to the mirrors.

Also added a test  `AutoReflect_DoesNotDeleteSource_WhenSourceNamespaceMatchesOwnPattern`
(real k3s via Testcontainers): a source in a namespace matching its own allowed
pattern, a namespace event fired on it, then the allowed list narrowed; asserts
the source survives. Fails on `main`, passes with the fix.